### PR TITLE
move more responsibilities into model specs

### DIFF
--- a/lua/kznllm.lua
+++ b/lua/kznllm.lua
@@ -1,43 +1,11 @@
 local M = {}
-local Job = require 'plenary.job'
 local api = vim.api
-
---- Inserts content at the current cursor position in the active Neovim buffer.
----
---- This function schedules the insertion to occur on the next event loop iteration,
---- ensuring it doesn't interfere with other ongoing Neovim operations.
----
---- @param content string The text content to be inserted at the cursor position.
----
---- Behavior:
---- 1. Retrieves the current cursor position.
---- 2. Splits the input content into lines.
---- 3. Uses 'undojoin' to prevent creating an undo state for every token.
---- 4. Inserts the content at the cursor position.
---- 5. Moves the cursor to the end of the inserted content.
----
---- Note: This function modifies the current buffer and cursor position.
-local function write_content_at_cursor(content)
-  vim.schedule(function()
-    local row, col = unpack(api.nvim_win_get_cursor(0))
-
-    local lines = vim.split(content, '\n')
-
-    -- avoid flooding undo history
-    vim.cmd 'undojoin'
-    api.nvim_put(lines, 'c', true, true)
-
-    local num_lines = #lines
-    local last_line_length = #lines[num_lines]
-    api.nvim_win_set_cursor(0, { row + num_lines - 1, col + last_line_length })
-  end)
-end
 
 --- Handle visual selection using the start of the visual selection and current
 --- cursor position in the most common modes (i.e. visual, visual lines, visual block)
 ---
 --- Note: visual block is handled the same as visual lines
---- @return string[]
+--- @return string
 local function get_visual_selection()
   -- use this instead of vim.api.nvim_buf_get_mark because it gives the "last" visual selection
   local _, srow, scol = unpack(vim.fn.getpos 'v')
@@ -64,73 +32,38 @@ local function get_visual_selection()
   -- after getting lines, exit visual mode and go to end of the current line
   api.nvim_feedkeys(api.nvim_replace_termcodes('<Esc>', false, true, true), 'nx', false)
   api.nvim_feedkeys('$', 'nx', false)
-  return lines
-end
+  local content = table.concat(lines, '\n')
 
---- Constructs a prompt string from an array of lines and resets the editor state.
----
---- This function takes an array of strings, concatenates them into a single string
---- with newline separators, and performs some editor state management actions.
----
---- @param lines string[] An array of strings to be concatenated into a prompt.
---- @return string
-local function get_prompt(lines)
-  local prompt = ''
-
-  if lines then
-    prompt = table.concat(lines, '\n')
+  if content == '' then
+    vim.print 'no prompt selection found... use a [v]isual selection mode'
   end
 
-  return prompt
+  return content
 end
 
 local group = api.nvim_create_augroup('LLM_AutoGroup', { clear = true })
-local active_job = nil
 
 --- Invokes an LLM via a supported API spec
 ---
 --- Must provide the function for constructing cURL arguments and a handler
 --- function for processing server-sent events.
 ---
----@param opts { api_key_name: string, url: string, model: string, system_prompt: string, prompt: string }
----@param make_curl_args_fn function
----@param handle_data_fn function
-function M.invoke_llm_and_stream_into_editor(opts, make_curl_args_fn, handle_data_fn)
+---@param opts { api_key_name: string, url: string, model: string, system_prompt: string }
+---@param make_job_fn function
+function M.invoke_llm_and_stream_into_editor(opts, make_job_fn)
   api.nvim_clear_autocmds { group = group }
 
-  local visual_lines = get_visual_selection()
-  local prompt = get_prompt(visual_lines)
-  if prompt == '' then
-    vim.print 'no prompt selection found... use a [v]isual selection mode'
-    return
+  local user_prompt = get_visual_selection()
+
+  if opts.system_prompt == nil then
+    opts.system_prompt = 'You are a tsundere uwu anime. Yell at me for not setting my configuration for my llm plugin correctly'
   end
 
-  local system_prompt = opts.system_prompt or 'You are a tsundere uwu anime. Yell at me for not setting my configuration for my llm plugin correctly'
-  local args = make_curl_args_fn(opts, prompt, system_prompt)
+  local active_job = make_job_fn(opts, user_prompt)
 
   -- put new line, enter visual mode to highlight the completion
   api.nvim_put({ '' }, 'l', true, true)
   api.nvim_feedkeys('v', 'nx', true)
-
-  if active_job then
-    active_job:shutdown()
-    active_job = nil
-  end
-
-  active_job = Job:new {
-    command = 'curl',
-    args = args,
-    on_stdout = function(_, out)
-      local content = handle_data_fn(out)
-      if content ~= '' then
-        write_content_at_cursor(content)
-      end
-    end,
-    on_stderr = function(_, _) end,
-    on_exit = function()
-      active_job = nil
-    end,
-  }
 
   active_job:start()
 
@@ -141,13 +74,11 @@ function M.invoke_llm_and_stream_into_editor(opts, make_curl_args_fn, handle_dat
       if active_job then
         active_job:shutdown()
         print 'LLM streaming cancelled'
-        active_job = nil
       end
     end,
   })
 
   api.nvim_set_keymap('n', '<Esc>', ':doautocmd User LLM_Escape<CR>', { noremap = true, silent = true })
-  return active_job
 end
 
 return M

--- a/lua/kznllm/specs/anthropic.lua
+++ b/lua/kznllm/specs/anthropic.lua
@@ -1,0 +1,112 @@
+local M = {}
+
+local Job = require 'plenary.job'
+local utils = require 'kznllm.utils'
+local active_job = nil
+local current_event_state = nil
+
+--- Constructs arguments for constructing an HTTP request to the Anthropic API
+--- using cURL.
+---
+---@param opts { api_key_name: string, url: string, model: string, system_prompt: string }
+---@param user_prompt string
+---@return string[]
+local function make_curl_args(opts, user_prompt)
+  local url = opts.url
+  local api_key = opts.api_key_name and os.getenv(opts.api_key_name)
+  local data = {
+    system = opts.system_prompt,
+    messages = { { role = 'user', content = user_prompt } },
+    model = opts.model,
+    stream = true,
+    max_tokens = 4096,
+  }
+  local args = { '-N', '-X', 'POST', '-H', 'Content-Type: application/json', '-d', vim.json.encode(data) }
+  if api_key then
+    table.insert(args, '-H')
+    table.insert(args, 'x-api-key: ' .. api_key)
+    table.insert(args, '-H')
+    table.insert(args, 'anthropic-version: 2023-06-01')
+  end
+  table.insert(args, url)
+  return args
+end
+
+--- Anthropic SSE Specification
+--- [See Documentation](https://docs.anthropic.com/en/api/messages-streaming#event-types)
+---
+--- Each server-sent event includes a named event type and associated JSON
+--- data. Each event will use an SSE event name (e.g. event: message_stop),
+--- and include the matching event type in its data.
+---
+--- Each stream uses the following event flow:
+---
+--- 1. `message_start`: contains a Message object with empty content.
+---
+--- 2. A series of content blocks, each of which have a `content_block_start`,
+---    one or more `content_block_delta` events, and a `content_block_stop`
+---    event. Each content block will have an index that corresponds to its
+---    index in the final Message content array.
+---
+--- 3. One or more `message_delta` events, indicating top-level changes to the
+---    final Message object.
+--- 4. `message_stop` event
+---
+--- event types: `[message_start, content_block_start, content_block_delta, content_block_stop, message_delta, message_stop, error]`
+---@param data string
+---@return string
+local function handle_data(data)
+  local content = ''
+  if data then
+    local json = vim.json.decode(data)
+
+    if json.delta and json.delta.text then
+      content = json.delta.text
+    end
+  end
+
+  return content
+end
+
+function M.make_job(opts, user_prompt)
+  if active_job then
+    active_job:shutdown()
+    active_job = nil
+  end
+
+  active_job = Job:new {
+    command = 'curl',
+    args = make_curl_args(opts, user_prompt),
+    on_stdout = function(_, out)
+      -- based on sse spec (Anthropic spec has several distinct events)
+      -- Anthropic's sse spec requires you to manage the current event state
+      local _, event_epos = string.find(out, '^event: ')
+
+      if event_epos then
+        current_event_state = string.sub(out, event_epos + 1)
+        return
+      end
+
+      if current_event_state == 'content_block_delta' then
+        local data, data_epos
+        _, data_epos = string.find(out, '^data: ')
+
+        if data_epos then
+          data = string.sub(out, data_epos + 1)
+        end
+
+        local content = handle_data(data)
+        if content ~= '' then
+          utils.write_content_at_cursor(content)
+        end
+      end
+    end,
+    on_stderr = function(_, _) end,
+    on_exit = function()
+      active_job = nil
+    end,
+  }
+  return active_job
+end
+
+return M

--- a/lua/kznllm/utils.lua
+++ b/lua/kznllm/utils.lua
@@ -1,0 +1,35 @@
+local M = {}
+local api = vim.api
+
+--- Inserts content at the current cursor position in the active Neovim buffer.
+---
+--- This function schedules the insertion to occur on the next event loop iteration,
+--- ensuring it doesn't interfere with other ongoing Neovim operations.
+---
+--- @param content string The text content to be inserted at the cursor position.
+---
+--- Behavior:
+--- 1. Retrieves the current cursor position.
+--- 2. Splits the input content into lines.
+--- 3. Uses 'undojoin' to prevent creating an undo state for every token.
+--- 4. Inserts the content at the cursor position.
+--- 5. Moves the cursor to the end of the inserted content.
+---
+--- Note: This function modifies the current buffer and cursor position.
+function M.write_content_at_cursor(content)
+  vim.schedule(function()
+    local row, col = unpack(api.nvim_win_get_cursor(0))
+
+    local lines = vim.split(content, '\n')
+
+    -- avoid flooding undo history
+    vim.cmd 'undojoin'
+    api.nvim_put(lines, 'c', true, true)
+
+    local num_lines = #lines
+    local last_line_length = #lines[num_lines]
+    api.nvim_win_set_cursor(0, { row + num_lines - 1, col + last_line_length })
+  end)
+end
+
+return M


### PR DESCRIPTION
Might be a slightly questionable refactor... so writing out some thoughts here.

high-level changes:
* specs are responsible for job creation
  * it was awkward that the user can mess with the curl args function and sse data handler... but they weren't expected to mess with the "event state logic" even though this is inherently quite coupled with the model spec anyways.
  * there's basically no point of allowing the user to "configure" something behind the black box. By the time they are messing with curl args and what not, they already have to have to already have your code cloned/forked tbh.
* job stdout handler is reponsible for sse parsing + state management (anthropic)
  * there aren't an endless number of model providers... yet. But the sse parser logic is basically dictated by the model provider. Now that specs are responsible for making the jobs too, I can also leave it up to the model spec to manage event state if needed or do something special with the events (or in OpenAI spec... there's no state to manage)
* move writer into utils
  * felt weird for "the thing that writes into my buffer" to be in a job... but it's also weird that it's grouped together with the logic that's grabbing the visual selection. only the "jobs" are doing the writing, so it feels right to place it somewhere closer to the model specs
* roll up `get_prompt` into `get_visual_selection` - it was kind of redundant anyways

At the end of all these changes, most of the complex stuff is now sitting in model specs whereas the top-level module is just holding the stuff that's closest to neovim (i.e. key bindings, get visual selection, start job, cancel job, etc.)

some earlier changes were around simplifying `get_visual_selection` to just do the swap upfront to cut down any confusion and remove replace because it's only a few vim keys away anyways.