### PR TITLE
Refactor more complexity into spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ I recommend you fork the repo and make it work for you.
 
 We're at a point in history where "AI-powered editor" is probably one of the best "hello world" projects for learning about custom Neovim plugins.
 
-see [CONTRIBUTING](CONTRIBUTING.md)
+See [CONTRIBUTING](CONTRIBUTING.md) to understand the typical development workflow for Neovim plugins using `Lazy`.
 
 https://github.com/chottolabs/kznllm.nvim/assets/171991982/39da67df-1ebc-4866-b563-f6b30d393162
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 Based on [dingllm.nvim](https://github.com/yacineMTB/dingllm.nvim) - but it'll probably diverge quite a bit from the original state.
 
 - adds some docstring annotations
-- refactored to better express some of the inherent coupling in the interaction
+- refactored to better express some of the inherent coupling
 between neovim <> some LLM streaming spec.
 - prompt user for additional context
 - clean up and handle job state
 
+I recommend you fork the repo and make it work for you.
+
+We're at a point in history where "AI-powered editor" is probably one of the best "hello world" projects for learning about custom Neovim plugins.
+
+see [CONTRIBUTING](CONTRIBUTING.md)
 
 https://github.com/chottolabs/kznllm.nvim/assets/171991982/39da67df-1ebc-4866-b563-f6b30d393162
 
@@ -29,35 +34,16 @@ export GROQ_API_KEY=gsk_...
     local kznllm = require 'kznllm'
     local spec = require 'kznllm.specs.anthropic'
 
-    local helpful_prompt = [[
-You are an AI programming assistant integrated into a code editor. Your purpose is to help the user with programming tasks as they write code.
-Key capabilities:
-- Thoroughly analyze the user's code and provide insightful suggestions for improvements related to best practices, performance, readability, and maintainability. Explain your reasoning.
-- Answer coding questions in detail, using examples from the user's own code when relevant. Break down complex topics step- Spot potential bugs and logical errors. Alert the user and suggest fixes.
-- Upon request, add helpful comments explaining complex or unclear code.
-- Suggest relevant documentation, StackOverflow answers, and other resources related to the user's code and questions.
-- Engage in back-and-forth conversations to understand the user's intent and provide the most helpful information.
-- Keep concise and use markdown.
-- When asked to create code, only generate the code. No bugs.
-- Think step by step]]
-
     local function llm_help()
       kznllm.invoke_llm_and_stream_into_editor({
-        url = 'https://api.anthropic.com/v1/messages',
-        model = 'claude-3-5-sonnet-20240620',
-        api_key_name = 'ANTHROPIC_API_KEY',
-        system_prompt = helpful_prompt,
+        system_prompt = spec.PROMPT_TEMPLATES.HELPFUL_PROMPT,
+        replace = false,
       }, spec.make_job)
     end
 
-    local replace_prompt =
-      [[You should replace the code that you are sent, only following the comments. Do not talk at all. Only output valid code. Do not provide any backticks that surround the code. Never ever output backticks like this ```. Any comment that is asking you for something should be removed after you satisfy them. Other comments should left alone. Do not output backticks]]
     local function llm_replace()
       kznllm.invoke_llm_and_stream_into_editor({
-        url = 'https://api.anthropic.com/v1/messages',
-        model = 'claude-3-5-sonnet-20240620',
-        api_key_name = 'ANTHROPIC_API_KEY',
-        system_prompt = replace_prompt,
+        system_prompt = spec.PROMPT_TEMPLATES.REPLACE_PROMPT,
         replace = true,
       }, spec.make_job)
     end
@@ -65,7 +51,7 @@ Key capabilities:
     vim.keymap.set({ 'n', 'v' }, '<leader>k', llm_replace, { desc = 'Send current selection to LLM llm_replace' })
     vim.keymap.set({ 'n', 'v' }, '<leader>K', llm_help, { desc = 'Send current selection to LLM llm_help' })
   end,
-}
+},
 ```
 
 or for groq
@@ -79,10 +65,15 @@ or for groq
     ...
     local function llm_help()
       kznllm.invoke_llm_and_stream_into_editor({
-        url = 'https://api.groq.com/openai/v1/chat/completions',
-        model = 'llama3-70b-8192',
-        api_key_name = 'GROQ_API_KEY',
-        system_prompt = helpful_prompt,
+        system_prompt = spec.PROMPT_TEMPLATES.HELPFUL_PROMPT,
+        replace = false,
+      }, spec.make_job)
+    end
+
+    local function llm_replace()
+      kznllm.invoke_llm_and_stream_into_editor({
+        system_prompt = spec.PROMPT_TEMPLATES.REPLACE_PROMPT,
+        replace = true,
       }, spec.make_job)
     end
     ...

--- a/lua/kznllm.lua
+++ b/lua/kznllm.lua
@@ -100,7 +100,7 @@ local group = api.nvim_create_augroup('LLM_AutoGroup', { clear = true })
 --- Must provide the function for constructing cURL arguments and a handler
 --- function for processing server-sent events.
 ---
----@param opts { api_key_name: string, url: string, model: string, system_prompt: string, replace: boolean }
+---@param opts { model: string, system_prompt: string, replace: boolean }
 ---@param make_job_fn function
 function M.invoke_llm_and_stream_into_editor(opts, make_job_fn)
   api.nvim_clear_autocmds { group = group }
@@ -146,7 +146,7 @@ function M.invoke_llm_and_stream_into_editor(opts, make_job_fn)
 
   local user_prompt = table.concat({ visual_selection, replace_prompt }, '\n')
 
-  local active_job = make_job_fn(opts, system_prompt, user_prompt)
+  local active_job = make_job_fn(system_prompt, user_prompt)
   active_job:start()
   api.nvim_create_autocmd('User', {
     group = group,

--- a/lua/kznllm/specs/openai.lua
+++ b/lua/kznllm/specs/openai.lua
@@ -1,4 +1,33 @@
 local M = {}
+M.API_KEY_NAME = 'GROQ_API_KEY'
+M.URL = 'https://api.groq.com/openai/v1/chat/completions'
+
+M.MODELS = {
+  LLAMA_3_70B = 'llama3-70b-8192',
+}
+M.SELECTED_MODEL = M.MODELS.LLAMA_3_70B
+
+M.PROMPT_TEMPLATES = {
+  --- this prompt should let the model yap into a separate buffer
+  HELPFUL_PROMPT = [[You are an AI programming assistant integrated into a code editor. Your purpose is to help the user with programming tasks as they write code.
+Key capabilities:
+- Thoroughly analyze the user's code and provide insightful suggestions for improvements related to best practices, performance, readability, and maintainability. Explain your reasoning.
+- Answer coding questions in detail, using examples from the user's own code when relevant. Break down complex topics step- Spot potential bugs and logical errors. Alert the user and suggest fixes.
+- Upon request, add helpful comments explaining complex or unclear code.
+- Suggest relevant documentation, StackOverflow answers, and other resources related to the user's code and questions.
+- Engage in back-and-forth conversations to understand the user's intent and provide the most helpful information.
+- Keep concise and use markdown.
+- When asked to create code, only generate the code. No bugs.
+- Think step by step]],
+
+  --- this prompt has to be written to output valid code
+  REPLACE_PROMPT = [[You should replace the code that you are sent, only following the comments. Do not talk at all. Only output valid code. Do not provide any backticks that surround the code. Never ever output backticks like this ```. Any comment that is asking you for something should be removed after you satisfy them. Other comments should left alone. Do not output backticks]],
+}
+
+local API_ERROR_MESSAGE = [[
+ERROR: groq api key is set to %s and is missing from your environment variables.
+
+Load somewhere safely from config `export %s=<api_key>`]]
 
 local Job = require 'plenary.job'
 local utils = require 'kznllm.utils'
@@ -6,16 +35,15 @@ local utils = require 'kznllm.utils'
 --- Constructs arguments for constructing an HTTP request to the OpenAI API
 --- using cURL.
 ---
----@param opts { api_key_name: string, url: string, model: string }
 ---@param user_prompt string
 ---@param system_prompt string
 ---@return string[]
-local function make_curl_args(opts, system_prompt, user_prompt)
-  local url = opts.url
-  local api_key = opts.api_key_name and os.getenv(opts.api_key_name)
+local function make_curl_args(system_prompt, user_prompt)
+  local url = M.URL
+  local api_key = os.getenv(M.API_KEY_NAME)
   local data = {
     messages = { { role = 'system', content = system_prompt }, { role = 'user', content = user_prompt } },
-    model = opts.model,
+    model = M.SELECTED_MODEL,
     temperature = 0.7,
     stream = true,
   }
@@ -23,6 +51,8 @@ local function make_curl_args(opts, system_prompt, user_prompt)
   if api_key then
     table.insert(args, '-H')
     table.insert(args, 'Authorization: Bearer ' .. api_key)
+  else
+    error(string.format(API_ERROR_MESSAGE, M.API_KEY_NAME, M.API_KEY_NAME), 1)
   end
   table.insert(args, url)
   return args
@@ -46,10 +76,10 @@ local function handle_data(data)
   return content
 end
 
-function M.make_job(opts, system_prompt, user_prompt)
+function M.make_job(system_prompt, user_prompt)
   local active_job = Job:new {
     command = 'curl',
-    args = make_curl_args(opts, system_prompt, user_prompt),
+    args = make_curl_args(system_prompt, user_prompt),
     on_stdout = function(_, out)
       -- based on sse spec (OpenAI spec uses data-only server-sent events)
       local data, data_epos

--- a/lua/kznllm/specs/openai.lua
+++ b/lua/kznllm/specs/openai.lua
@@ -94,7 +94,9 @@ function M.make_job(system_prompt, user_prompt)
         utils.write_content_at_cursor(content)
       end
     end,
-    on_stderr = function(_, _) end,
+    on_stderr = function(message, _)
+      error(message, 1)
+    end,
     on_exit = function() end,
   }
   return active_job


### PR DESCRIPTION
another very opinionated refactor, there's already a lot of inherent coupling with the logic of the plugin - not much of it is actually that configurable and it just makes things confusing if it's not setup exactly the right way.

Instead of dependency injecting a bunch of configurations via `opts` I can get rid of it entirely because all of the opts are fully scoped to model specs.

I think this refactor is actually clean because it lets the user take advantage of type hints (which I assume is set up already because we're literally writing a neovim plugin)

<img width="1157" alt="Screenshot 2024-07-13 at 9 50 56 PM" src="https://github.com/user-attachments/assets/efbd4184-e6d3-4630-b8ed-d9b5d0b8da71">

It's also pretty good because we can still override it by writing something like `spec.API_KEY_NAME = <api_key>` since the module variables only kick in at runtime anyways

Now the only logic that is deeply coupled is the fact that there are two "modes" - one in which it opens up a scratch buffer you can throw away (`replace = false`) and one which is basically a code infill (`replace = true`) - which I think makes sense... maybe I'll also provide that as an enum in a separate refactor.