### PR TITLE
refactor + free up the cursor in buffer mode

### DIFF
--- a/lua/kznllm.lua
+++ b/lua/kznllm.lua
@@ -79,7 +79,7 @@ function M.invoke_llm_buffer_mode(opts, make_job_fn)
     api.nvim_win_set_cursor(0, { new_line_count + #context_lines, 0 })
   else
     local filepath = M.CACHE_DIRECTORY .. tostring(os.time()) .. '.txt'
-    utils.create_input_buffer(
+    input_buf_nr = utils.create_input_buffer(
       input_buf_nr,
       filepath,
       table.concat {

--- a/lua/kznllm.lua
+++ b/lua/kznllm.lua
@@ -41,15 +41,15 @@ local function create_input_buffer(initial_content)
   api.nvim_buf_set_name(input_buf_nr, M.CACHE_DIRECTORY .. filename)
 
   -- Set the buffer as listed to keep it in the buffer list
-  api.nvim_buf_set_option(input_buf_nr, 'buflisted', true)
+  api.nvim_set_option_value('buflisted', true, { buf = input_buf_nr })
 
   -- Switch to the new buffer
   api.nvim_set_current_buf(input_buf_nr)
 
   -- Enable text wrapping
-  api.nvim_win_set_option(0, 'wrap', true)
-  api.nvim_win_set_option(0, 'linebreak', true)
-  api.nvim_win_set_option(0, 'breakindent', true)
+  api.nvim_set_option_value('wrap', true, { win = 0 })
+  api.nvim_set_option_value('linebreak', true, { win = 0 })
+  api.nvim_set_option_value('breakindent', true, { win = 0 })
 
   -- Set initial content
   api.nvim_buf_set_lines(input_buf_nr, 0, -1, false, vim.split(initial_content, '\n'))

--- a/lua/kznllm.lua
+++ b/lua/kznllm.lua
@@ -1,17 +1,20 @@
+local utils = require 'kznllm.utils'
 local M = {}
 local api = vim.api
+
+-- Global variable to store the buffer number
+local input_buf_nr = nil
+local group = api.nvim_create_augroup('LLM_AutoGroup', { clear = true })
 
 -- Specify the path where you want to save the file
 M.CACHE_DIRECTORY = (os.getenv 'HOME' or os.getenv 'USERPROFILE') .. '/.cache/kznllm/history/'
 
 local success, error_message = os.execute('mkdir -p "' .. M.CACHE_DIRECTORY .. '"')
+
 if not success then
   print('Error creating directory: ' .. error_message)
   return
 end
-
--- Global variable to store the buffer number
-local input_buf_nr = nil
 
 local context_template = [[
 
@@ -30,104 +33,6 @@ Arguments:
 ---
 
 ]]
--- Define the function that creates the buffer and handles the input
-local function create_input_buffer(initial_content)
-  -- Convert timestamp to string and append .txt extension
-  local filename = tostring(os.time()) .. '.txt'
-
-  input_buf_nr = api.nvim_create_buf(true, false)
-  api.nvim_buf_set_name(input_buf_nr, M.CACHE_DIRECTORY .. filename)
-  api.nvim_set_option_value('buflisted', true, { buf = input_buf_nr })
-
-  api.nvim_set_current_buf(input_buf_nr)
-  api.nvim_set_option_value('wrap', true, { win = 0 })
-  api.nvim_set_option_value('linebreak', true, { win = 0 })
-  api.nvim_set_option_value('breakindent', true, { win = 0 })
-
-  -- Set initial content
-  api.nvim_buf_set_lines(input_buf_nr, 0, -1, false, vim.split(initial_content, '\n'))
-
-  local num_lines = api.nvim_buf_line_count(input_buf_nr)
-  api.nvim_win_set_cursor(0, { num_lines, 0 })
-
-  -- Set up autocmd to clear the buffer number when it's deleted
-  api.nvim_create_autocmd('BufDelete', {
-    buffer = input_buf_nr,
-    callback = function()
-      input_buf_nr = nil
-    end,
-  })
-
-  -- Set up key mapping to close the buffer
-  api.nvim_buf_set_keymap(input_buf_nr, 'n', 'w', '', {
-    noremap = true,
-    silent = true,
-    callback = function()
-      -- Trigger the LLM_Escape event
-      api.nvim_exec_autocmds('User', { pattern = 'LLM_Escape' })
-
-      api.nvim_buf_call(input_buf_nr, function()
-        vim.cmd 'write'
-      end)
-
-      -- Switch to the previous buffer
-      api.nvim_command 'buffer #'
-    end,
-  })
-
-  -- Set up key mapping to close the buffer
-  api.nvim_buf_set_keymap(input_buf_nr, 'n', 'q', '', {
-    noremap = true,
-    silent = true,
-    callback = function()
-      -- Trigger the LLM_Escape event
-      api.nvim_exec_autocmds('User', { pattern = 'LLM_Escape' })
-
-      api.nvim_buf_call(input_buf_nr, function()
-        vim.cmd 'bdelete!'
-      end)
-    end,
-  })
-end
-
---- Handle visual selection using the start of the visual selection and current
---- cursor position in the most common modes (i.e. visual, visual lines, visual block)
----
---- Note: visual block is handled the same as visual lines
---- @return string
-local function get_visual_selection()
-  -- use this instead of vim.api.nvim_buf_get_mark because it gives the "last" visual selection
-  local _, srow, scol = unpack(vim.fn.getpos 'v')
-  local _, erow, ecol = unpack(vim.fn.getpos '.')
-  local mode = api.nvim_get_mode().mode
-
-  -- Ensure start is before end
-  if srow > erow or (srow == erow and scol > ecol) then
-    srow, erow = erow, srow
-    scol, ecol = ecol, scol
-    -- move cursor to the other end of visual selection
-    api.nvim_feedkeys('o', 'nx', false)
-  end
-
-  local lines = {}
-  if mode == 'V' or mode == '\22' then
-    lines = api.nvim_buf_get_lines(0, srow - 1, erow, false)
-  elseif (srow == erow) and (scol == ecol) then
-    lines = {}
-  else
-    lines = api.nvim_buf_get_text(0, srow - 1, scol - 1, erow - 1, ecol, {})
-  end
-
-  local content = table.concat(lines, '\n')
-
-  if content == '' then
-    vim.print 'no prompt selection found... use a [v]isual selection mode'
-  end
-
-  return content
-end
-
-local group = api.nvim_create_augroup('LLM_AutoGroup', { clear = true })
 
 --- Invokes an LLM via a supported API spec in "buffer" mode
 ---
@@ -139,7 +44,7 @@ local group = api.nvim_create_augroup('LLM_AutoGroup', { clear = true })
 function M.invoke_llm_buffer_mode(opts, make_job_fn)
   api.nvim_clear_autocmds { group = group }
 
-  local visual_selection = get_visual_selection()
+  local visual_selection = utils.get_visual_selection()
 
   if opts.prompt_template == nil then
     opts.prompt_template = 'You are a tsundere uwu anime. Yell at me for not setting my configuration for my llm plugin correctly'
@@ -173,7 +78,15 @@ function M.invoke_llm_buffer_mode(opts, make_job_fn)
     api.nvim_buf_set_lines(input_buf_nr, new_line_count, new_line_count, false, context_lines)
     api.nvim_win_set_cursor(0, { new_line_count + #context_lines, 0 })
   else
-    create_input_buffer(table.concat { opts.prompt_template, context_template:format(unpack(user_prompt_args)) })
+    local filepath = M.CACHE_DIRECTORY .. tostring(os.time()) .. '.txt'
+    utils.create_input_buffer(
+      input_buf_nr,
+      filepath,
+      table.concat {
+        opts.prompt_template,
+        context_template:format(unpack(user_prompt_args)),
+      }
+    )
   end
 
   local active_job = make_job_fn(opts.prompt_template, user_prompt_args)
@@ -200,7 +113,7 @@ end
 function M.invoke_llm_replace_mode(opts, make_job_fn)
   api.nvim_clear_autocmds { group = group }
 
-  local visual_selection = get_visual_selection()
+  local visual_selection = utils.get_visual_selection()
 
   if opts.prompt_template == nil then
     opts.prompt_template = 'You are a tsundere uwu anime. Yell at me for not setting my configuration for my llm plugin correctly'
@@ -211,7 +124,6 @@ function M.invoke_llm_replace_mode(opts, make_job_fn)
 
   local active_job = make_job_fn(opts.prompt_template, user_prompt_args)
   active_job:start()
-
   api.nvim_create_autocmd('User', {
     group = group,
     pattern = 'LLM_Escape',

--- a/lua/kznllm.lua
+++ b/lua/kznllm.lua
@@ -89,7 +89,7 @@ function M.invoke_llm_buffer_mode(opts, make_job_fn)
     )
   end
 
-  local active_job = make_job_fn(opts.prompt_template, user_prompt_args)
+  local active_job = make_job_fn(opts.prompt_template, user_prompt_args, utils.write_content_at_end)
   active_job:start()
   api.nvim_create_autocmd('User', {
     group = group,
@@ -122,7 +122,7 @@ function M.invoke_llm_replace_mode(opts, make_job_fn)
   local user_prompt_args = { visual_selection }
   api.nvim_feedkeys('c', 'nx', false)
 
-  local active_job = make_job_fn(opts.prompt_template, user_prompt_args)
+  local active_job = make_job_fn(opts.prompt_template, user_prompt_args, utils.write_content_at_cursor)
   active_job:start()
   api.nvim_create_autocmd('User', {
     group = group,

--- a/lua/kznllm.lua
+++ b/lua/kznllm.lua
@@ -188,8 +188,6 @@ function M.invoke_llm_buffer_mode(opts, make_job_fn)
       end
     end,
   })
-
-  api.nvim_set_keymap('n', '<Esc>', ':doautocmd User LLM_Escape<CR>', { noremap = true, silent = true })
 end
 
 --- Invokes an LLM via a supported API spec in "replace" mode
@@ -213,6 +211,7 @@ function M.invoke_llm_replace_mode(opts, make_job_fn)
 
   local active_job = make_job_fn(opts.prompt_template, user_prompt_args)
   active_job:start()
+
   api.nvim_create_autocmd('User', {
     group = group,
     pattern = 'LLM_Escape',
@@ -223,8 +222,14 @@ function M.invoke_llm_replace_mode(opts, make_job_fn)
       end
     end,
   })
-
-  api.nvim_set_keymap('n', '<Esc>', ':doautocmd User LLM_Escape<CR>', { noremap = true, silent = true })
 end
+
+api.nvim_set_keymap('n', '<Esc>', '', {
+  noremap = true,
+  silent = true,
+  callback = function()
+    api.nvim_exec_autocmds('User', { pattern = 'LLM_Escape' })
+  end,
+})
 
 return M

--- a/lua/kznllm.lua
+++ b/lua/kznllm.lua
@@ -35,18 +35,11 @@ local function create_input_buffer(initial_content)
   -- Convert timestamp to string and append .txt extension
   local filename = tostring(os.time()) .. '.txt'
 
-  -- Create a new buffer
   input_buf_nr = api.nvim_create_buf(true, false)
-
   api.nvim_buf_set_name(input_buf_nr, M.CACHE_DIRECTORY .. filename)
-
-  -- Set the buffer as listed to keep it in the buffer list
   api.nvim_set_option_value('buflisted', true, { buf = input_buf_nr })
 
-  -- Switch to the new buffer
   api.nvim_set_current_buf(input_buf_nr)
-
-  -- Enable text wrapping
   api.nvim_set_option_value('wrap', true, { win = 0 })
   api.nvim_set_option_value('linebreak', true, { win = 0 })
   api.nvim_set_option_value('breakindent', true, { win = 0 })
@@ -54,9 +47,8 @@ local function create_input_buffer(initial_content)
   -- Set initial content
   api.nvim_buf_set_lines(input_buf_nr, 0, -1, false, vim.split(initial_content, '\n'))
 
-  -- Add separator and move cursor after it
-  local new_line_count = api.nvim_buf_line_count(input_buf_nr)
-  api.nvim_win_set_cursor(0, { new_line_count, 0 })
+  local num_lines = api.nvim_buf_line_count(input_buf_nr)
+  api.nvim_win_set_cursor(0, { num_lines, 0 })
 
   -- Set up autocmd to clear the buffer number when it's deleted
   api.nvim_create_autocmd('BufDelete', {

--- a/lua/kznllm/specs/anthropic.lua
+++ b/lua/kznllm/specs/anthropic.lua
@@ -87,7 +87,6 @@ ERROR: anthropic api key is set to %s and is missing from your environment varia
 Load somewhere safely from config `export %s=<api_key>`]]
 
 local Job = require 'plenary.job'
-local utils = require 'kznllm.utils'
 local current_event_state = nil
 
 --- Constructs arguments for constructing an HTTP request to the Anthropic API
@@ -159,7 +158,7 @@ local function handle_data(data)
   return content
 end
 
-function M.make_job(prompt_template, user_prompt_args)
+function M.make_job(prompt_template, user_prompt_args, writer_fn)
   local active_job = Job:new {
     command = 'curl',
     args = make_curl_args(prompt_template:format(unpack(user_prompt_args))),
@@ -187,7 +186,7 @@ function M.make_job(prompt_template, user_prompt_args)
 
         local content = handle_data(data)
         if content and content ~= nil then
-          utils.write_content_at_cursor(content)
+          writer_fn(content)
         end
       elseif current_event_state == 'message_start' then
         local data, data_epos

--- a/lua/kznllm/specs/openai.lua
+++ b/lua/kznllm/specs/openai.lua
@@ -30,7 +30,6 @@ ERROR: groq api key is set to %s and is missing from your environment variables.
 Load somewhere safely from config `export %s=<api_key>`]]
 
 local Job = require 'plenary.job'
-local utils = require 'kznllm.utils'
 
 --- Constructs arguments for constructing an HTTP request to the OpenAI API
 --- using cURL.
@@ -76,7 +75,7 @@ local function handle_data(data)
   return content
 end
 
-function M.make_job(system_prompt, user_prompt)
+function M.make_job(system_prompt, user_prompt, writer_fn)
   local active_job = Job:new {
     command = 'curl',
     args = make_curl_args(system_prompt, user_prompt),
@@ -91,7 +90,7 @@ function M.make_job(system_prompt, user_prompt)
 
       local content = handle_data(data)
       if content and content ~= nil then
-        utils.write_content_at_cursor(content)
+        writer_fn(content)
       end
     end,
     on_stderr = function(message, _)

--- a/lua/kznllm/utils.lua
+++ b/lua/kznllm/utils.lua
@@ -37,13 +37,13 @@ end
 function M.write_content_at_end(content)
   vim.schedule(function()
     local current_pos = vim.api.nvim_win_get_cursor(0)
-    vim.cmd 'normal! G'
 
     local srow, erow, scol, ecol = -1, -1, -1, -1
     vim.cmd 'undojoin'
     local lines = vim.split(content, '\n')
     api.nvim_buf_set_text(0, srow, scol, erow, ecol, lines)
 
+    vim.cmd 'normal! G'
     api.nvim_win_set_cursor(0, current_pos)
   end)
 end

--- a/lua/kznllm/utils.lua
+++ b/lua/kznllm/utils.lua
@@ -34,4 +34,98 @@ function M.write_content_at_cursor(content)
   end)
 end
 
+-- Define the function that creates the buffer and handles the input
+function M.create_input_buffer(input_buf_nr, filepath, initial_content)
+  input_buf_nr = api.nvim_create_buf(true, false)
+  api.nvim_buf_set_name(input_buf_nr, filepath)
+  api.nvim_set_option_value('buflisted', true, { buf = input_buf_nr })
+
+  api.nvim_set_current_buf(input_buf_nr)
+  api.nvim_set_option_value('wrap', true, { win = 0 })
+  api.nvim_set_option_value('linebreak', true, { win = 0 })
+  api.nvim_set_option_value('breakindent', true, { win = 0 })
+
+  -- Set initial content
+  api.nvim_buf_set_lines(input_buf_nr, 0, -1, false, vim.split(initial_content, '\n'))
+
+  local num_lines = api.nvim_buf_line_count(input_buf_nr)
+  api.nvim_win_set_cursor(0, { num_lines, 0 })
+
+  -- Set up autocmd to clear the buffer number when it's deleted
+  api.nvim_create_autocmd('BufDelete', {
+    buffer = input_buf_nr,
+    callback = function()
+      input_buf_nr = nil
+    end,
+  })
+
+  -- Set up key mapping to close the buffer
+  api.nvim_buf_set_keymap(input_buf_nr, 'n', 'w', '', {
+    noremap = true,
+    silent = true,
+    callback = function()
+      -- Trigger the LLM_Escape event
+      api.nvim_exec_autocmds('User', { pattern = 'LLM_Escape' })
+
+      api.nvim_buf_call(input_buf_nr, function()
+        vim.cmd 'write'
+      end)
+
+      -- Switch to the previous buffer
+      api.nvim_command 'buffer #'
+    end,
+  })
+
+  -- Set up key mapping to close the buffer
+  api.nvim_buf_set_keymap(input_buf_nr, 'n', 'q', '', {
+    noremap = true,
+    silent = true,
+    callback = function()
+      -- Trigger the LLM_Escape event
+      api.nvim_exec_autocmds('User', { pattern = 'LLM_Escape' })
+
+      api.nvim_buf_call(input_buf_nr, function()
+        vim.cmd 'bdelete!'
+      end)
+    end,
+  })
+end
+
+--- Handle visual selection using the start of the visual selection and current
+--- cursor position in the most common modes (i.e. visual, visual lines, visual block)
+---
+--- Note: visual block is handled the same as visual lines
+--- @return string
+function M.get_visual_selection()
+  -- use this instead of vim.api.nvim_buf_get_mark because it gives the "last" visual selection
+  local _, srow, scol = unpack(vim.fn.getpos 'v')
+  local _, erow, ecol = unpack(vim.fn.getpos '.')
+  local mode = api.nvim_get_mode().mode
+
+  -- Ensure start is before end
+  if srow > erow or (srow == erow and scol > ecol) then
+    srow, erow = erow, srow
+    scol, ecol = ecol, scol
+    -- move cursor to the other end of visual selection
+    api.nvim_feedkeys('o', 'nx', false)
+  end
+
+  local lines = {}
+  if mode == 'V' or mode == '\22' then
+    lines = api.nvim_buf_get_lines(0, srow - 1, erow, false)
+  elseif (srow == erow) and (scol == ecol) then
+    lines = {}
+  else
+    lines = api.nvim_buf_get_text(0, srow - 1, scol - 1, erow - 1, ecol, {})
+  end
+
+  local content = table.concat(lines, '\n')
+
+  if content == '' then
+    vim.print 'no prompt selection found... use a [v]isual selection mode'
+  end
+
+  return content
+end
+
 return M

--- a/lua/kznllm/utils.lua
+++ b/lua/kznllm/utils.lua
@@ -103,6 +103,7 @@ function M.create_input_buffer(input_buf_nr, filepath, initial_content)
       end)
     end,
   })
+  return input_buf_nr
 end
 
 --- Handle visual selection using the start of the visual selection and current

--- a/lua/kznllm/utils.lua
+++ b/lua/kznllm/utils.lua
@@ -34,6 +34,20 @@ function M.write_content_at_cursor(content)
   end)
 end
 
+function M.write_content_at_end(content)
+  vim.schedule(function()
+    local current_pos = vim.api.nvim_win_get_cursor(0)
+    vim.cmd 'normal! G'
+
+    local srow, erow, scol, ecol = -1, -1, -1, -1
+    vim.cmd 'undojoin'
+    local lines = vim.split(content, '\n')
+    api.nvim_buf_set_text(0, srow, scol, erow, ecol, lines)
+
+    api.nvim_win_set_cursor(0, current_pos)
+  end)
+end
+
 -- Define the function that creates the buffer and handles the input
 function M.create_input_buffer(input_buf_nr, filepath, initial_content)
   input_buf_nr = api.nvim_create_buf(true, false)


### PR DESCRIPTION
thinking about adding a structured output mode, freeing the cursor is a start tho.

- `kznllm.lua` is responsible for all the logic that implements the various modes
- specs probably should've never imported utils before, the only thing that jobs still need to be responsible for is writing - but that shouldn't matter much to the spec.
  - buffer mode uses `write_at_end`, replace mode uses `write_at_cursor` (dep injected into the `make_job_fn`)
- buffer mode has a free cursor now because there's now a `write_at_end` writer function that can keep streaming the tokens to the bottom of the buffer while you can move around and do whatever (i.e. before can't navigate or you would completely mess with the outputs)
  - might figure out how to do this for the replace mode too - a bit more weird because i have to maintain the state of lines added by the LLM