### PR TITLE
free the cursor in replace mode

### DIFF
--- a/lua/kznllm.lua
+++ b/lua/kznllm.lua
@@ -324,7 +324,11 @@ function M.invoke_llm_replace_mode(opts, make_job_fn)
   local stream_end_extmark_id = api.nvim_buf_set_extmark(0, kznllm_ns, crow - 1, -1, {})
   local active_job = make_job_fn(rendered_messages, function(content)
     utils.write_content_at_extmark(content, kznllm_ns, stream_end_extmark_id)
-  end, function() end)
+  end, function()
+    vim.schedule(function()
+      api.nvim_buf_del_extmark(0, kznllm_ns, stream_end_extmark_id)
+    end)
+  end)
   active_job:start()
   api.nvim_create_autocmd('User', {
     group = group,

--- a/lua/kznllm/utils.lua
+++ b/lua/kznllm/utils.lua
@@ -41,6 +41,20 @@ function M.write_content_at_cursor(content)
 end
 
 ---@param content string
+---@param ns_id integer
+---@param extmark_id integer
+function M.write_content_at_extmark(content, ns_id, extmark_id)
+  vim.schedule(function()
+    local extmark = api.nvim_buf_get_extmark_by_id(0, ns_id, extmark_id, { details = false })
+    local row, col = extmark[1], extmark[2]
+
+    vim.cmd 'undojoin'
+    local lines = vim.split(content, '\n')
+    api.nvim_buf_set_text(0, row, col, row, col, lines)
+  end)
+end
+
+---@param content string
 function M.write_content_at_end(content)
   vim.schedule(function()
     local current_pos = vim.api.nvim_win_get_cursor(0)


### PR DESCRIPTION
new discovery in nvim lua api actually changes everything... I can replace all the `write_content_at_location` type functions and do some cooler stuff without forcing the user to keep the cursor in place.

https://neovim.io/doc/user/api.html#_extended-marks

it basically saves a position in the buffer, but it updates properly when you are inserting text before it