### PR TITLE
Refactor v0.2 - hand over control to the user

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,8 @@ For developing any kind of plugin using `lazy.nvim` you basically just need to d
 - point the plugin to local directory
 - update the plugin using `:Lazy` and confirm it's looking at the local directory
 
+For development, you want to install the plugin locally and update your lazy config like this (same as the main project README with `dev = true` and `dir = path/to/plugin`):
+
 ```lua
 {
   'chottolabs/kznllm.nvim',
@@ -10,53 +12,30 @@ For developing any kind of plugin using `lazy.nvim` you basically just need to d
   dir = '$HOME/.config/nvim/plugins/kznllm.nvim',
   dependencies = {
     { 'nvim-lua/plenary.nvim' },
-    { 'stevearc/dressing.nvim' },
+    -- { 'chottolabs/plenary.nvim' }, -- patched to resolve symlinked directories
   },
-  
-  -- this points to whatever you specified as the local `dir = path` in above
-  kznllm.TEMPLATE_DIRECTORY = vim.fn.expand(self.dir) .. '/templates/'
-
-  spec.SELECTED_MODEL = { name = 'hermes-3-llama-3.1-405b-fp8' }
-  spec.API_KEY_NAME = 'LAMBDA_API_KEY'
-  spec.URL = 'https://api.lambdalabs.com/v1/chat/completions'
-
-  local function invoke_llm()
-    kznllm.invoke_llm({
-      -- add more user/assistant stages to this and just supply a path to your custom template directories
-      -- every prompt template gets sent the same table of args for simplicity sake, add custom args as needed
-      { role = 'system', prompt_template = spec.PROMPT_TEMPLATES.NOUS_RESEARCH.FILL_MODE_SYSTEM_PROMPT },
-      { role = 'user', prompt_template = spec.PROMPT_TEMPLATES.NOUS_RESEARCH.FILL_MODE_USER_PROMPT },
-    }, spec.make_job)
+  config = function(self)
+  ...
   end
-
-  -- add a new keymap with a new behavior
-  vim.keymap.set({ 'n', 'v' }, '<leader>k', invoke_llm, { desc = 'Send current selection to LLM invoke_llm' })
 },
 ```
 
-This is one of the major changes made, instead of specifying templates as specific arguments it's a single table of arbitrary templates.
+# Overview
 
-```lua
-kznllm.invoke_llm({
-  -- add more user/assistant stages to this and just supply a path to your custom template directories
-  -- every prompt template gets sent the same table of args for simplicity sake, add custom args as needed
-  { role = 'system', prompt_template = spec.PROMPT_TEMPLATES.NOUS_RESEARCH.FILL_MODE_SYSTEM_PROMPT },
-  { role = 'user', prompt_template = spec.PROMPT_TEMPLATES.NOUS_RESEARCH.FILL_MODE_USER_PROMPT },
-}, spec.make_job)
-```
+`kznllm` (since `v0.2`) at its core provides:
 
-If you go into `init.lua` and focus on `invoke_llm` function there's this one table of arguments that gets passed to all the prompt templates. Most of the logic is dictated by the jinja template itself.
+1. a set of utility functions for pulling context from files on disk and/or your active nvim instance.
+2. a minimal implementation of specs from API providers that are relevant to helping you stream tokens into a nvim buffer
 
-```lua
-local prompt_args = {
-  current_buffer_path = current_buffer_path,
-  current_buffer_context = current_buffer_context,
-  current_buffer_filetype = current_buffer_filetype,
-  visual_selection = visual_selection,
-  user_query = input,
-  replace = replace_mode,
-}
-```
+If you take a look at `lua/kznllm/presets.lua` you can learn how I built out the entire feature set of kznllm in `v0.1` by basically stitching together utility functions from the core library and telling neovim what you want to do with it (i.e. open up scratch buffers, specify extmark position, etc.)
+
+You don't have to use anything from presets at all, it's just there to provide a starting point for making the plugin functional. It can be relatively simple to add new features/capabilities for example:
+
+- a workflow for interactively cycling through a dataset and triggering an LLM evaluation
+- add an intermediate API call to a cheap/fast model for a long-context "project mode"
+- ask an slow/expensive model to freely output a response and pipe it into a cheap/fast model for structured output
+
+## Prompt Templates
 
 The "no visual selection mode" is really just a "no replace" mode controlled by `local replace_mode = not (mode == 'n')`.
 
@@ -72,19 +51,3 @@ You are a Senior Engineer at a Fortune 500 Company. You will be provided with co
 
 An interesting thing you might consider is implementing a "project-scoped" template directory that can look for documentation files and pipe it into the args (you can do this with the actual text or the file path `{% include <absolute_file_path> %}`). `minijinja-cli` makes this kind of stuff super easy to do.
 
-_Note: Can't be bothered to read about how the event loop works in nvim so it gets weird when I'm using "vim.ui" and other async APIs._
-
-## Debugging
-
-Make sure to include something like this in your config
-
-```lua
-local function debug()
-  kznllm.invoke_llm({
-    { role = 'system', prompt_template = spec.PROMPT_TEMPLATES.FILL_MODE_SYSTEM_PROMPT },
-    { role = 'user', prompt_template = spec.PROMPT_TEMPLATES.FILL_MODE_USER_PROMPT },
-  }, spec.make_job, { debug = true })
-end
-
-vim.keymap.set({ 'n', 'v' }, '<leader>d', debug, { desc = 'Send current selection to LLM debug' })
-```

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ full config w/ supported presets and a switch mechanism and provider-specific de
 minimal configuration with custom `make_data_fn` and no preset switcher. As you can see, the `make_data_fn` is simply building the `data` portion of the API call and will accept anything supported by the associated provider.
 
 ```lua
+local presets = require 'kznllm'
 local presets = require 'kznllm.presets'
 local Path = require 'plenary.path'
 
@@ -195,4 +196,3 @@ end
 
 vim.keymap.set({ 'n', 'v' }, '<leader>k', llm_fill, { desc = 'Send current selection to LLM llm_fill' })
 ```
-

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ full config w/ supported presets and a switch mechanism and provider-specific de
     -- falls back to `vim.fn.stdpath 'data' .. '/lazy/kznllm/templates'` when the plugin is not locally installed
     local TEMPLATE_DIRECTORY = Path:new(vim.fn.expand(self.dir) .. '/templates')
 
+    -- edit this to change the selected preset (or just fork the repo and add your own)
     local SELECTED_PRESET = presets[1]
     local spec = require(('kznllm.specs.%s'):format(SELECTED_PRESET.provider))
 

--- a/lua/kznllm/init.lua
+++ b/lua/kznllm/init.lua
@@ -279,7 +279,7 @@ function M.invoke_llm(make_data_fn, make_curl_args_fn, make_job_fn, opts)
       opts.debug_fn(data, stream_end_extmark_id, opts)
     else
       local _, crow, ccol = unpack(vim.fn.getpos '.')
-      stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol - 1, {})
+      stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol, { strict = false })
     end
 
     local args = make_curl_args_fn(data, opts)

--- a/lua/kznllm/init.lua
+++ b/lua/kznllm/init.lua
@@ -62,7 +62,13 @@ function M.write_content_at_extmark(content, extmark_id)
 
   local lines = vim.split(content, '\n')
 
-  vim.cmd 'undojoin'
+  -- Check if there are any pending changes in the buffer
+  local undo_sequence_active = vim.bo.modified
+
+  -- Use 'undojoin' only if an undo sequence is active
+  if undo_sequence_active then
+    vim.cmd 'undojoin'
+  end
   api.nvim_buf_set_text(0, mrow, mcol, mrow, mcol, lines)
 end
 

--- a/lua/kznllm/init.lua
+++ b/lua/kznllm/init.lua
@@ -60,20 +60,6 @@ function M.make_scratch_buffer()
 
   local num_lines = api.nvim_buf_line_count(buf_id)
   api.nvim_win_set_cursor(0, { num_lines, 0 })
-
-  -- Set up key mapping to close the buffer
-  api.nvim_buf_set_keymap(buf_id, 'n', '<leader>q', '', {
-    noremap = true,
-    silent = true,
-    callback = function()
-      -- Trigger the LLM_Escape event
-      api.nvim_exec_autocmds('User', { pattern = 'LLM_Escape' })
-
-      api.nvim_buf_call(buf_id, function()
-        vim.cmd 'bdelete!'
-      end)
-    end,
-  })
   return buf_id
 end
 

--- a/lua/kznllm/init.lua
+++ b/lua/kznllm/init.lua
@@ -32,6 +32,10 @@ local group = api.nvim_create_augroup('LLM_AutoGroup', { clear = true })
 ---@param prompt_args table typically PROMPT_ARGS_STATE which needs to be json encoded
 ---@return string rendered_prompt
 function M.make_prompt_from_template(prompt_template_path, prompt_args)
+  if vim.fn.executable 'minijinja-cli' ~= 1 then
+    error("Can't find minijinja-cli, download it from https://github.com/mitsuhiko/minijinja or add it to $PATH", 1)
+  end
+
   if not prompt_template_path:exists() then
     error(string.format('could not find template at %s', prompt_template_path), 1)
   end
@@ -71,9 +75,9 @@ function M.make_scratch_buffer()
 
   M.BUFFER_STATE.SCRATCH = api.nvim_create_buf(true, false)
 
-  api.nvim_buf_set_name(M.BUFFER_STATE.SCRATCH, 'debug.md')
-  api.nvim_set_option_value('buflisted', true, { buf = M.BUFFER_STATE.SCRATCH })
+  -- api.nvim_set_option_value('buflisted', true, { buf = M.BUFFER_STATE.SCRATCH })
   api.nvim_set_option_value('filetype', 'markdown', { buf = M.BUFFER_STATE.SCRATCH })
+  api.nvim_set_option_value('swapfile', false, { buf = M.BUFFER_STATE.SCRATCH })
 
   api.nvim_set_current_buf(M.BUFFER_STATE.SCRATCH)
   api.nvim_set_option_value('wrap', true, { win = 0 })
@@ -237,10 +241,6 @@ end
 ---@param make_curl_args_fn fun(data: table, opts: table)
 ---@param make_job_fn fun(rendered_message: { role: string, content: string }, writer_fn: fun(content: string), on_exit_fn: fun())
 function M.invoke_llm(make_data_fn, make_curl_args_fn, make_job_fn, opts)
-  if vim.fn.executable 'minijinja-cli' ~= 1 then
-    error("Can't find minijinja-cli, download it from https://github.com/mitsuhiko/minijinja or add it to $PATH", 1)
-  end
-
   api.nvim_clear_autocmds { group = group }
 
   local active_job

--- a/lua/kznllm/init.lua
+++ b/lua/kznllm/init.lua
@@ -284,6 +284,7 @@ function M.invoke_llm(make_data_fn, make_curl_args_fn, make_job_fn, opts)
 
     local args = make_curl_args_fn(data, opts)
 
+    -- Make a no-op change to the buffer at the specified extmark to avoid calling undojoin after undo
     noop(stream_end_extmark_id)
 
     active_job = make_job_fn(args, function(content)

--- a/lua/kznllm/init.lua
+++ b/lua/kznllm/init.lua
@@ -52,7 +52,7 @@ end
 
 ---@param content string
 ---@param extmark_id integer
-local function write_content_at_extmark(content, extmark_id)
+function M.write_content_at_extmark(content, extmark_id)
   local extmark = api.nvim_buf_get_extmark_by_id(0, M.NS_ID, extmark_id, { details = false })
   local mrow, mcol = extmark[1], extmark[2]
 
@@ -267,22 +267,16 @@ function M.invoke_llm(make_data_fn, make_curl_args_fn, make_job_fn, opts)
       M.PROMPT_ARGS_STATE.current_buffer_context = buf_context
     end
 
-    local data = make_data_fn(M.PROMPT_ARGS_STATE, opts)
-
     if opts and opts.debug then
       stream_end_extmark_id = M.make_scratch_buffer()
-      for _, message in ipairs(data.messages) do
-        write_content_at_extmark(message.role .. ':\n\n', stream_end_extmark_id)
-        write_content_at_extmark(message.content, stream_end_extmark_id)
-        write_content_at_extmark('\n\n---\n\n', stream_end_extmark_id)
-        vim.cmd 'normal! G'
-      end
     end
+
+    local data = make_data_fn(M.PROMPT_ARGS_STATE, opts)
 
     local args = make_curl_args_fn(data, opts)
 
     active_job = make_job_fn(args, function(content)
-      write_content_at_extmark(content, stream_end_extmark_id)
+      M.write_content_at_extmark(content, stream_end_extmark_id)
     end, function()
       api.nvim_buf_del_extmark(0, M.NS_ID, stream_end_extmark_id)
     end)

--- a/lua/kznllm/init.lua
+++ b/lua/kznllm/init.lua
@@ -24,8 +24,6 @@ M.PROMPT_ARGS_STATE = {
 
 M.NS_ID = api.nvim_create_namespace 'kznllm_ns'
 
-M.TEMPLATE_DIRECTORY = vim.fn.stdpath 'data' .. '/lazy/kznllm/templates'
-
 local group = api.nvim_create_augroup('LLM_AutoGroup', { clear = true })
 
 ---Renders a prompt template using minijinja-cli and returns the rendered lines

--- a/lua/kznllm/presets.lua
+++ b/lua/kznllm/presets.lua
@@ -155,8 +155,8 @@ function M.invoke_llm(make_data_fn, make_curl_args_fn, make_job_fn, opts)
       M.PROMPT_ARGS_STATE.context_files = kznllm.get_project_files(context_dir, opts)
     end
 
-    -- don't update current context when in debug mode
-    if M.BUFFER_STATE.SCRATCH == nil then
+    -- don't update current context if scratch buffer is open
+    if not M.BUFFER_STATE.SCRATCH or (not api.nvim_buf_is_valid(M.BUFFER_STATE.SCRATCH)) then
       -- similar to rendering a template, but we want to get the context of the file without relying on the changes being saved
       local buf_filetype, buf_path, buf_context = kznllm.get_buffer_context(M.BUFFER_STATE.ORIGIN, opts)
       M.PROMPT_ARGS_STATE.current_buffer_filetype = buf_filetype

--- a/lua/kznllm/presets.lua
+++ b/lua/kznllm/presets.lua
@@ -31,7 +31,7 @@ M.NS_ID = api.nvim_create_namespace 'kznllm_ns'
 local group = api.nvim_create_augroup('LLM_AutoGroup', { clear = true })
 ---Example implementation of a `make_data_fn` compatible with `kznllm.invoke_llm` for groq spec
 ---@param prompt_args any
----@param opts { model: string, temperature: number, template_directory: Path, debug: boolean }
+---@param opts { model: string, temperature: number, min_p: number, template_directory: Path, debug: boolean }
 ---@return table
 ---
 local function make_data_for_openai_chat(prompt_args, opts)
@@ -48,6 +48,7 @@ local function make_data_for_openai_chat(prompt_args, opts)
     },
     model = opts.model,
     temperature = opts.temperature,
+    min_p = opts.min_p,
     stream = true,
   }
 
@@ -243,7 +244,9 @@ local presets = {
     opts = {
       model = 'hermes-3-llama-3.1-405b-fp8',
       max_tokens = 8192,
-      temperature = 0.7,
+      -- temperature = 0.7,
+      min_p = 0.9,
+      temperature = 2.1,
       debug_fn = openai_debug_fn,
       base_url = 'https://api.lambdalabs.com',
       endpoint = '/v1/chat/completions',
@@ -280,15 +283,15 @@ local presets = {
   {
     id = 'completion-model',
     provider = 'vllm',
-    make_data_fn = make_data_for_openai_completions,
+    make_data_fn = make_data_for_openai_chat,
     debug_fn = openai_debug_fn,
     opts = {
-      model = 'meta-llama/Meta-Llama-3.1-8B',
+      model = 'meta-llama/Meta-Llama-3.1-8B-Instruct',
       max_tokens = 8192,
       min_p = 0.9,
       temperature = 2.1,
-      debug_fn = vllm_completions_debug_fn,
-      endpoint = '/v1/completions',
+      debug_fn = openai_debug_fn,
+      endpoint = '/v1/chat/completions',
     },
   },
 }

--- a/lua/kznllm/presets.lua
+++ b/lua/kznllm/presets.lua
@@ -1,4 +1,5 @@
 local kznllm = require 'kznllm'
+local TEMPLATE_DIRECTORY = vim.fn.stdpath 'data' .. '/lazy/kznllm/templates'
 
 ---Example implementation of a `make_data_fn` compatible with `kznllm.invoke_llm` for groq spec
 ---@param prompt_args any
@@ -103,7 +104,7 @@ end
 -- { id = 'openai', opts = { api_key_name = 'VLLM_API_KEY', url = 'http://research.local:8000/v1/chat/completions' } }
 local presets = {
   {
-    id = 'basic-chat-model',
+    id = 'chat-model',
     provider = 'groq',
     make_data_fn = make_data_for_openai_chat,
     opts = {
@@ -116,7 +117,7 @@ local presets = {
     },
   },
   {
-    id = 'basic-chat-model',
+    id = 'chat-model',
     provider = 'lambda',
     make_data_fn = make_data_for_openai_chat,
     opts = {
@@ -129,7 +130,7 @@ local presets = {
     },
   },
   {
-    id = 'basic-chat-model',
+    id = 'chat-model',
     provider = 'anthropic',
     make_data_fn = make_data_for_anthropic_chat,
     debug_fn = anthropic_debug_fn,
@@ -143,7 +144,7 @@ local presets = {
     },
   },
   {
-    id = 'basic-chat-model',
+    id = 'chat-model',
     provider = 'openai',
     make_data_fn = make_data_for_openai_chat,
     debug_fn = openai_debug_fn,
@@ -157,7 +158,7 @@ local presets = {
     },
   },
   {
-    id = 'basic-chat-model',
+    id = 'completion-model',
     provider = 'vllm',
     make_data_fn = make_data_for_openai_completions,
     debug_fn = openai_debug_fn,

--- a/lua/kznllm/presets.lua
+++ b/lua/kznllm/presets.lua
@@ -1,25 +1,45 @@
 local kznllm = require 'kznllm'
-local TEMPLATE_DIRECTORY = vim.fn.stdpath 'data' .. '/lazy/kznllm/templates'
+local api = vim.api
 
+local M = {}
+
+-- ORIGIN refers to the buffer where the user invoked the plugin.
+-- SCRATCH is a temporary buffer for debugging/chat.
+M.BUFFER_STATE = {
+  SCRATCH = nil,
+  ORIGIN = nil,
+}
+
+M.PROMPT_ARGS_STATE = {
+  current_buffer_path = nil,
+  current_buffer_context = nil,
+  current_buffer_filetype = nil,
+  visual_selection = nil,
+  user_query = nil,
+  replace = nil,
+  context_files = nil,
+}
+
+M.NS_ID = api.nvim_create_namespace 'kznllm_ns'
+
+local group = api.nvim_create_augroup('LLM_AutoGroup', { clear = true })
 ---Example implementation of a `make_data_fn` compatible with `kznllm.invoke_llm` for groq spec
 ---@param prompt_args any
 ---@param opts { model: string, temperature: number, template_directory: Path, debug: boolean }
 ---@return table
 ---
 local function make_data_for_openai_chat(prompt_args, opts)
-  local messages = {
-    {
-      role = 'system',
-      content = kznllm.make_prompt_from_template(opts.template_directory / 'nous_research/fill_mode_system_prompt.xml.jinja', prompt_args),
-    },
-    {
-      role = 'user',
-      content = kznllm.make_prompt_from_template(opts.template_directory / 'nous_research/fill_mode_user_prompt.xml.jinja', prompt_args),
-    },
-  }
-
   local data = {
-    messages = messages,
+    messages = {
+      {
+        role = 'system',
+        content = kznllm.make_prompt_from_template(opts.template_directory / 'nous_research/fill_mode_system_prompt.xml.jinja', prompt_args),
+      },
+      {
+        role = 'user',
+        content = kznllm.make_prompt_from_template(opts.template_directory / 'nous_research/fill_mode_user_prompt.xml.jinja', prompt_args),
+      },
+    },
     model = opts.model,
     temperature = opts.temperature,
     stream = true,
@@ -66,38 +86,121 @@ local function make_data_for_openai_completions(prompt_args, opts)
   return data
 end
 
-local function openai_debug_fn(data, extmark_id, opts)
-  kznllm.write_content_at_extmark('model: ' .. opts.model, extmark_id)
-  kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+local function openai_debug_fn(data, ns_id, extmark_id, opts)
+  kznllm.write_content_at_extmark('model: ' .. opts.model, ns_id, extmark_id)
+  kznllm.write_content_at_extmark('\n\n---\n\n', ns_id, extmark_id)
   for _, message in ipairs(data.messages) do
-    kznllm.write_content_at_extmark(message.role .. ':\n\n', extmark_id)
-    kznllm.write_content_at_extmark(message.content, extmark_id)
-    kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+    kznllm.write_content_at_extmark(message.role .. ':\n\n', ns_id, extmark_id)
+    kznllm.write_content_at_extmark(message.content, ns_id, extmark_id)
+    kznllm.write_content_at_extmark('\n\n---\n\n', ns_id, extmark_id)
     vim.cmd 'normal! G'
   end
 end
 
-local function vllm_completions_debug_fn(data, extmark_id, opts)
-  kznllm.write_content_at_extmark('model: ' .. opts.model, extmark_id)
-  kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
-  kznllm.write_content_at_extmark(data.prompt, extmark_id)
-  kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+local function vllm_completions_debug_fn(data, ns_id, extmark_id, opts)
+  kznllm.write_content_at_extmark('model: ' .. opts.model, ns_id, extmark_id)
+  kznllm.write_content_at_extmark('\n\n---\n\n', ns_id, extmark_id)
+  kznllm.write_content_at_extmark(data.prompt, ns_id, extmark_id)
+  kznllm.write_content_at_extmark('\n\n---\n\n', ns_id, extmark_id)
   vim.cmd 'normal! G'
 end
 
-local function anthropic_debug_fn(data, extmark_id, opts)
-  kznllm.write_content_at_extmark('model: ' .. opts.model, extmark_id)
-  kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+local function anthropic_debug_fn(data, ns_id, extmark_id, opts)
+  kznllm.write_content_at_extmark('model: ' .. opts.model, ns_id, extmark_id)
+  kznllm.write_content_at_extmark('\n\n---\n\n', ns_id, extmark_id)
 
-  kznllm.write_content_at_extmark('system' .. ':\n\n', extmark_id)
-  kznllm.write_content_at_extmark(data.system, extmark_id)
-  kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+  kznllm.write_content_at_extmark('system' .. ':\n\n', ns_id, extmark_id)
+  kznllm.write_content_at_extmark(data.system, ns_id, extmark_id)
+  kznllm.write_content_at_extmark('\n\n---\n\n', ns_id, extmark_id)
   for _, message in ipairs(data.messages) do
-    kznllm.write_content_at_extmark(message.role .. ':\n\n', extmark_id)
-    kznllm.write_content_at_extmark(message.content, extmark_id)
-    kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+    kznllm.write_content_at_extmark(message.role .. ':\n\n', ns_id, extmark_id)
+    kznllm.write_content_at_extmark(message.content, ns_id, extmark_id)
+    kznllm.write_content_at_extmark('\n\n---\n\n', ns_id, extmark_id)
     vim.cmd 'normal! G'
   end
+end
+
+--- Working implementation of "inline" fill mode
+--- Invokes an LLM via a supported API spec defined by
+---
+--- Must provide the function for constructing cURL arguments and a handler
+--- function for processing server-sent events.
+---
+---@param make_data_fn fun(prompt_args: table, opts: table)
+---@param make_curl_args_fn fun(data: table, opts: table)
+---@param make_job_fn fun(data: table, writer_fn: fun(content: string), on_exit_fn: fun())
+---@param opts { debug: string?, debug_fn: fun(data: table, ns_id: integer, extmark_id: integer, opts: table)?, stop_dir: Path?, context_dir_id: string? }
+function M.invoke_llm(make_data_fn, make_curl_args_fn, make_job_fn, opts)
+  api.nvim_clear_autocmds { group = group }
+
+  local active_job
+
+  M.BUFFER_STATE.ORIGIN = api.nvim_win_get_buf(0)
+
+  kznllm.get_user_input(function(input)
+    M.PROMPT_ARGS_STATE.user_query = input
+    M.PROMPT_ARGS_STATE.replace = not (api.nvim_get_mode().mode == 'n')
+
+    local visual_selection = kznllm.get_visual_selection(opts)
+    M.PROMPT_ARGS_STATE.visual_selection = visual_selection
+
+    local context_dir = kznllm.find_context_directory(opts)
+    if context_dir then
+      M.PROMPT_ARGS_STATE.context_files = kznllm.get_project_files(context_dir, opts)
+    end
+
+    -- don't update current context when in debug mode
+    if M.BUFFER_STATE.SCRATCH == nil then
+      -- similar to rendering a template, but we want to get the context of the file without relying on the changes being saved
+      local buf_filetype, buf_path, buf_context = kznllm.get_buffer_context(M.BUFFER_STATE.ORIGIN, opts)
+      M.PROMPT_ARGS_STATE.current_buffer_filetype = buf_filetype
+      M.PROMPT_ARGS_STATE.current_buffer_path = buf_path
+      M.PROMPT_ARGS_STATE.current_buffer_context = buf_context
+    end
+
+    local data = make_data_fn(M.PROMPT_ARGS_STATE, opts)
+
+    local stream_end_extmark_id
+
+    -- open up scratch buffer before setting extmark
+    if opts and opts.debug and opts.debug_fn then
+      if M.BUFFER_STATE.SCRATCH then
+        api.nvim_buf_delete(M.BUFFER_STATE.SCRATCH, { force = true })
+        M.BUFFER_STATE.SCRATCH = nil
+      end
+      M.BUFFER_STATE.SCRATCH = kznllm.make_scratch_buffer()
+
+      stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.SCRATCH, M.NS_ID, 0, 0, {})
+      opts.debug_fn(data, M.NS_ID, stream_end_extmark_id, opts)
+    else
+      local _, crow, ccol = unpack(vim.fn.getpos '.')
+      stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol, { strict = false })
+    end
+
+    local args = make_curl_args_fn(data, opts)
+
+    -- Make a no-op change to the buffer at the specified extmark to avoid calling undojoin after undo
+    kznllm.noop(M.NS_ID, stream_end_extmark_id)
+
+    active_job = make_job_fn(args, function(content)
+      kznllm.write_content_at_extmark(content, M.NS_ID, stream_end_extmark_id)
+    end, function()
+      api.nvim_buf_del_extmark(0, M.NS_ID, stream_end_extmark_id)
+    end)
+
+    active_job:start()
+
+    api.nvim_create_autocmd('User', {
+      group = group,
+      pattern = 'LLM_Escape',
+      callback = function()
+        if active_job.is_shutdown ~= true then
+          active_job:shutdown()
+          print 'LLM streaming cancelled'
+        end
+      end,
+    })
+  end)
 end
 
 -- for vllm, add openai w/ kwargs (i.e. url + api_key)
@@ -173,4 +276,4 @@ local presets = {
   },
 }
 
-return presets
+return vim.tbl_extend('keep', M, presets)

--- a/lua/kznllm/presets.lua
+++ b/lua/kznllm/presets.lua
@@ -1,7 +1,13 @@
+--
+-- This module provides the basic feature set from kznllm v0.1 with the addition of exported presets.
+-- Your lazy config still wants to define the keymaps to make it work (see the main project README.md for recommended setup)
+--
 local kznllm = require 'kznllm'
 local api = vim.api
 
 local M = {}
+
+--TODO: PROMPT_ARGS_STATE is just a bad persistence layer at the moment, I don't really want to write files everywhere...
 
 -- ORIGIN refers to the buffer where the user invoked the plugin.
 -- SCRATCH is a temporary buffer for debugging/chat.

--- a/lua/kznllm/presets.lua
+++ b/lua/kznllm/presets.lua
@@ -1,0 +1,175 @@
+local kznllm = require 'kznllm'
+
+---Example implementation of a `make_data_fn` compatible with `kznllm.invoke_llm` for groq spec
+---@param prompt_args any
+---@param opts { model: string, temperature: number, template_directory: Path, debug: boolean }
+---@return table
+---
+local function make_data_for_openai_chat(prompt_args, opts)
+  local messages = {
+    {
+      role = 'system',
+      content = kznllm.make_prompt_from_template(opts.template_directory / 'nous_research/fill_mode_system_prompt.xml.jinja', prompt_args),
+    },
+    {
+      role = 'user',
+      content = kznllm.make_prompt_from_template(opts.template_directory / 'nous_research/fill_mode_user_prompt.xml.jinja', prompt_args),
+    },
+  }
+
+  local data = {
+    messages = messages,
+    model = opts.model,
+    temperature = opts.temperature,
+    stream = true,
+  }
+
+  return data
+end
+
+---Example implementation of a `make_data_fn` compatible with `kznllm.invoke_llm` for anthropic spec
+---@param prompt_args any
+---@param opts any
+---@return table
+local function make_data_for_anthropic_chat(prompt_args, opts)
+  local data = {
+    system = kznllm.make_prompt_from_template(opts.template_directory / 'anthropic/fill_mode_system_prompt.xml.jinja', {}),
+    messages = {
+      {
+        role = 'user',
+        content = kznllm.make_prompt_from_template(opts.template_directory / 'anthropic/fill_mode_user_prompt.xml.jinja', prompt_args),
+      },
+    },
+    model = opts.model,
+    temperature = opts.temperature,
+    stream = true,
+    max_tokens = opts.max_tokens,
+  }
+
+  return data
+end
+
+---Example implementation of a `make_data_fn` compatible with `kznllm.invoke_llm` for vllm completions spec
+---@param prompt_args any
+---@param opts any
+---@return table
+local function make_data_for_openai_completions(prompt_args, opts)
+  local data = {
+    prompt = kznllm.make_prompt_from_template(opts.template_directory / 'vllm/fill_mode_instruct_completion_prompt.xml.jinja', prompt_args),
+    model = opts.model,
+    temperature = 1.5,
+    min_p = 1.0,
+    stream = true,
+  }
+
+  return data
+end
+
+local function openai_debug_fn(data, extmark_id, opts)
+  kznllm.write_content_at_extmark('model: ' .. opts.model, extmark_id)
+  kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+  for _, message in ipairs(data.messages) do
+    kznllm.write_content_at_extmark(message.role .. ':\n\n', extmark_id)
+    kznllm.write_content_at_extmark(message.content, extmark_id)
+    kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+    vim.cmd 'normal! G'
+  end
+end
+
+local function vllm_completions_debug_fn(data, extmark_id, opts)
+  kznllm.write_content_at_extmark('model: ' .. opts.model, extmark_id)
+  kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+  kznllm.write_content_at_extmark(data.prompt, extmark_id)
+  kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+  vim.cmd 'normal! G'
+end
+
+local function anthropic_debug_fn(data, extmark_id, opts)
+  kznllm.write_content_at_extmark('model: ' .. opts.model, extmark_id)
+  kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+
+  kznllm.write_content_at_extmark('system' .. ':\n\n', extmark_id)
+  kznllm.write_content_at_extmark(data.system, extmark_id)
+  kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+  for _, message in ipairs(data.messages) do
+    kznllm.write_content_at_extmark(message.role .. ':\n\n', extmark_id)
+    kznllm.write_content_at_extmark(message.content, extmark_id)
+    kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+    vim.cmd 'normal! G'
+  end
+end
+
+-- for vllm, add openai w/ kwargs (i.e. url + api_key)
+-- { id = 'openai', opts = { api_key_name = 'VLLM_API_KEY', url = 'http://research.local:8000/v1/chat/completions' } }
+local presets = {
+  {
+    id = 'basic-chat-model',
+    provider = 'groq',
+    make_data_fn = make_data_for_openai_chat,
+    opts = {
+      model = 'llama-3.1-70b-versatile',
+      max_tokens = 8192,
+      temperature = 0.7,
+      debug_fn = openai_debug_fn,
+      base_url = 'https://api.groq.com',
+      endpoint = '/openai/v1/chat/completions',
+    },
+  },
+  {
+    id = 'basic-chat-model',
+    provider = 'lambda',
+    make_data_fn = make_data_for_openai_chat,
+    opts = {
+      model = 'hermes-3-llama-3.1-405b-fp8',
+      max_tokens = 8192,
+      temperature = 0.7,
+      debug_fn = openai_debug_fn,
+      base_url = 'https://api.lambdalabs.com',
+      endpoint = '/v1/chat/completions',
+    },
+  },
+  {
+    id = 'basic-chat-model',
+    provider = 'anthropic',
+    make_data_fn = make_data_for_anthropic_chat,
+    debug_fn = anthropic_debug_fn,
+    opts = {
+      model = 'claude-3-5-sonnet-20240620',
+      max_tokens = 8192,
+      temperature = 0.7,
+      debug_fn = openai_debug_fn,
+      base_url = 'https://api.anthropic.com',
+      endpoint = '/v1/messages',
+    },
+  },
+  {
+    id = 'basic-chat-model',
+    provider = 'openai',
+    make_data_fn = make_data_for_openai_chat,
+    debug_fn = openai_debug_fn,
+    opts = {
+      model = 'gpt-4o-mini',
+      max_tokens = 16384,
+      temperature = 0.7,
+      debug_fn = openai_debug_fn,
+      base_url = 'https://api.openai.com',
+      endpoint = '/v1/chat/completions',
+    },
+  },
+  {
+    id = 'basic-chat-model',
+    provider = 'vllm',
+    make_data_fn = make_data_for_openai_completions,
+    debug_fn = openai_debug_fn,
+    opts = {
+      model = 'meta-llama/Meta-Llama-3.1-8B',
+      max_tokens = 8192,
+      min_p = 0.9,
+      temperature = 2.1,
+      debug_fn = vllm_completions_debug_fn,
+      endpoint = '/v1/completions',
+    },
+  },
+}
+
+return presets

--- a/lua/kznllm/specs/groq.lua
+++ b/lua/kznllm/specs/groq.lua
@@ -43,16 +43,11 @@ end
 --- Process server-sent events based on OpenAI spec
 --- [See Documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream)
 ---
----@param out string
+---@param line string
 ---@return string
-local function handle_data(out)
+local function handle_data(line)
   -- based on sse spec (OpenAI spec uses data-only server-sent events)
-  local data, data_epos
-  _, data_epos = string.find(out, '^data: ')
-
-  if data_epos then
-    data = string.sub(out, data_epos + 1)
-  end
+  local data = line:match '^data: (.+)$'
 
   local content = ''
 
@@ -74,8 +69,8 @@ function M.make_job(args, writer_fn, on_exit_fn)
   local active_job = Job:new {
     command = 'curl',
     args = args,
-    on_stdout = function(_, out)
-      local content = handle_data(out)
+    on_stdout = function(_, line)
+      local content = handle_data(line)
       if content and content ~= nil then
         vim.schedule(function()
           writer_fn(content)

--- a/lua/kznllm/specs/groq.lua
+++ b/lua/kznllm/specs/groq.lua
@@ -1,0 +1,152 @@
+local kznllm = require 'kznllm'
+local Path = require 'plenary.path'
+
+local M = {}
+
+local API_KEY_NAME = 'GROQ_API_KEY'
+local URL = 'https://api.groq.com/openai/v1/chat/completions'
+
+local TEMPLATE_PATH = vim.fn.expand(vim.fn.stdpath 'data') .. '/lazy/kznllm.nvim'
+
+M.MODELS = {
+  LLAMA_3_1_405B = { name = 'llama-3.1-405b-reasoning', max_tokens = 131072 },
+  LLAMA_3_1_70B = { name = 'llama-3.1-70b-versatile', max_tokens = 131072 },
+  LLAMA_3_70B = { name = 'llama3-70b-8192', max_tokens = 8192 },
+}
+
+M.MESSAGE_TEMPLATES = {
+
+  FILL_MODE_SYSTEM_PROMPT = 'nous_research/fill_mode_system_prompt.xml.jinja',
+  FILL_MODE_USER_PROMPT = 'nous_research/fill_mode_user_prompt.xml.jinja',
+
+  NOUS_RESEARCH = {
+    FILL_MODE_SYSTEM_PROMPT = 'nous_research/fill_mode_system_prompt.xml.jinja',
+    FILL_MODE_USER_PROMPT = 'nous_research/fill_mode_user_prompt.xml.jinja',
+  },
+
+  GROQ = {
+    --- this prompt has to be written to output valid code
+    FILL_MODE_SYSTEM_PROMPT = 'groq/fill_mode_system_prompt.xml.jinja',
+    FILL_MODE_USER_PROMPT = 'groq/fill_mode_user_prompt.xml.jinja',
+  },
+}
+
+local API_ERROR_MESSAGE = [[
+ERROR: api key name is set to %s and is missing from your environment variables.
+
+Load somewhere safely from config `export %s=<api_key>`]]
+
+local Job = require 'plenary.job'
+
+--- Constructs arguments for constructing an HTTP request to the OpenAI API
+--- using cURL.
+---
+---@param data table
+---@return string[]
+function M.make_curl_args(data, opts)
+  local url = opts and opts.url or URL
+  local api_key = os.getenv(opts and opts.api_key_name or API_KEY_NAME)
+
+  if not api_key then
+    error(API_ERROR_MESSAGE:format(API_KEY_NAME, API_KEY_NAME), 1)
+  end
+
+  local args = {
+    '-s', --silent
+    '-N', --no buffer
+    '-X',
+    'POST',
+    '-H',
+    'Content-Type: application/json',
+    '-d',
+    vim.json.encode(data),
+    '-H',
+    'Authorization: Bearer ' .. api_key,
+    url,
+  }
+
+  return args
+end
+
+--- Process server-sent events based on OpenAI spec
+--- [See Documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream)
+---
+---@param out string
+---@return string
+local function handle_data(out)
+  -- based on sse spec (OpenAI spec uses data-only server-sent events)
+  local data, data_epos
+  _, data_epos = string.find(out, '^data: ')
+
+  if data_epos then
+    data = string.sub(out, data_epos + 1)
+  end
+
+  local content = ''
+
+  if data and data:match '"delta":' then
+    local json = vim.json.decode(data)
+    if json.choices and json.choices[1] and json.choices[1].delta and json.choices[1].delta.content then
+      content = json.choices[1].delta.content
+    else
+      vim.print(data)
+    end
+  end
+
+  return content
+end
+
+---@param args table
+---@param writer_fn fun(content: string)
+function M.make_job(args, writer_fn, on_exit_fn)
+  local active_job = Job:new {
+    command = 'curl',
+    args = args,
+    on_stdout = function(_, out)
+      local content = handle_data(out)
+      if content and content ~= nil then
+        vim.schedule(function()
+          writer_fn(content)
+        end)
+      end
+    end,
+    on_stderr = function(message, _)
+      error(message, 1)
+    end,
+    on_exit = function()
+      vim.schedule(function()
+        on_exit_fn()
+      end)
+    end,
+  }
+  return active_job
+end
+
+---Example implementation of a `make_data_fn` compatible with `kznllm.invoke_llm` for groq spec
+---@param prompt_args any
+---@param opts any
+---@return table
+function M.make_data_for_chat(prompt_args, opts)
+  local template_path = Path:new(opts and opts.template_path or TEMPLATE_PATH)
+  local messages = {
+    {
+      role = 'system',
+      content = kznllm.make_prompt_from_template(template_path / M.MESSAGE_TEMPLATES.FILL_MODE_SYSTEM_PROMPT, prompt_args),
+    },
+    {
+      role = 'user',
+      content = kznllm.make_prompt_from_template(template_path / M.MESSAGE_TEMPLATES.FILL_MODE_USER_PROMPT, prompt_args),
+    },
+  }
+
+  local data = {
+    messages = messages,
+    model = M.MODELS.LLAMA_3_1_70B.name,
+    temperature = 0.7,
+    stream = true,
+  }
+
+  return data
+end
+
+return M

--- a/lua/kznllm/specs/lambda.lua
+++ b/lua/kznllm/specs/lambda.lua
@@ -43,16 +43,11 @@ end
 --- Process server-sent events based on OpenAI spec
 --- [See Documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream)
 ---
----@param out string
+---@param line string
 ---@return string
-local function handle_data(out)
+local function handle_data(line)
   -- based on sse spec (OpenAI spec uses data-only server-sent events)
-  local data, data_epos
-  _, data_epos = string.find(out, '^data: ')
-
-  if data_epos then
-    data = string.sub(out, data_epos + 1)
-  end
+  local data = line:match '^data: (.+)$'
 
   local content = ''
 
@@ -74,8 +69,8 @@ function M.make_job(args, writer_fn, on_exit_fn)
   local active_job = Job:new {
     command = 'curl',
     args = args,
-    on_stdout = function(_, out)
-      local content = handle_data(out)
+    on_stdout = function(_, line)
+      local content = handle_data(line)
       if content and content ~= nil then
         vim.schedule(function()
           writer_fn(content)

--- a/lua/kznllm/specs/lambda.lua
+++ b/lua/kznllm/specs/lambda.lua
@@ -3,38 +3,31 @@ local Path = require 'plenary.path'
 
 local M = {}
 
-local API_KEY_NAME = 'GROQ_API_KEY'
-local URL = 'https://api.groq.com/openai/v1/chat/completions'
+local API_KEY_NAME = 'LAMBDA_API_KEY'
+local URL = 'https://api.lambdalabs.com/v1/chat/completions'
 
 local TEMPLATE_PATH = vim.fn.expand(vim.fn.stdpath 'data') .. '/lazy/kznllm.nvim'
 
 M.MODELS = {
-  { name = 'llama-3.1-70b-versatile', max_tokens = 131072 },
-  { name = 'llama-3.1-405b-reasoning', max_tokens = 131072 },
-  { name = 'llama3-70b-8192', max_tokens = 8192 },
+  { name = 'hermes-3-llama-3.1-405b-fp8' },
 }
 
 M.SELECTED_MODEL_IDX = 1
 
+-- for chat completion models using `messages`
 M.MESSAGE_TEMPLATES = {
-
-  FILL_MODE_SYSTEM_PROMPT = 'nous_research/fill_mode_system_prompt.xml.jinja',
-  FILL_MODE_USER_PROMPT = 'nous_research/fill_mode_user_prompt.xml.jinja',
-
   NOUS_RESEARCH = {
     FILL_MODE_SYSTEM_PROMPT = 'nous_research/fill_mode_system_prompt.xml.jinja',
     FILL_MODE_USER_PROMPT = 'nous_research/fill_mode_user_prompt.xml.jinja',
   },
 
-  GROQ = {
-    --- this prompt has to be written to output valid code
-    FILL_MODE_SYSTEM_PROMPT = 'groq/fill_mode_system_prompt.xml.jinja',
-    FILL_MODE_USER_PROMPT = 'groq/fill_mode_user_prompt.xml.jinja',
-  },
+  -- defaults
+  FILL_MODE_SYSTEM_PROMPT = 'nous_research/fill_mode_system_prompt.xml.jinja',
+  FILL_MODE_USER_PROMPT = 'nous_research/fill_mode_user_prompt.xml.jinja',
 }
 
 local API_ERROR_MESSAGE = [[
-ERROR: api key name is set to %s and is missing from your environment variables.
+ERROR: api key is set to %s and is missing from your environment variables.
 
 Load somewhere safely from config `export %s=<api_key>`]]
 

--- a/lua/kznllm/specs/lambda.lua
+++ b/lua/kznllm/specs/lambda.lua
@@ -1,30 +1,7 @@
-local kznllm = require 'kznllm'
-local Path = require 'plenary.path'
-
 local M = {}
 
 local API_KEY_NAME = 'LAMBDA_API_KEY'
-local URL = 'https://api.lambdalabs.com/v1/chat/completions'
-
-local TEMPLATE_PATH = vim.fn.expand(vim.fn.stdpath 'data') .. '/lazy/kznllm.nvim'
-
-M.MODELS = {
-  { name = 'hermes-3-llama-3.1-405b-fp8' },
-}
-
-M.SELECTED_MODEL_IDX = 1
-
--- for chat completion models using `messages`
-M.MESSAGE_TEMPLATES = {
-  NOUS_RESEARCH = {
-    FILL_MODE_SYSTEM_PROMPT = 'nous_research/fill_mode_system_prompt.xml.jinja',
-    FILL_MODE_USER_PROMPT = 'nous_research/fill_mode_user_prompt.xml.jinja',
-  },
-
-  -- defaults
-  FILL_MODE_SYSTEM_PROMPT = 'nous_research/fill_mode_system_prompt.xml.jinja',
-  FILL_MODE_USER_PROMPT = 'nous_research/fill_mode_user_prompt.xml.jinja',
-}
+local BASE_URL = 'https://api.lambdalabs.com'
 
 local API_ERROR_MESSAGE = [[
 ERROR: api key is set to %s and is missing from your environment variables.
@@ -39,7 +16,7 @@ local Job = require 'plenary.job'
 ---@param data table
 ---@return string[]
 function M.make_curl_args(data, opts)
-  local url = opts and opts.url or URL
+  local url = (opts and opts.base_url or BASE_URL) .. (opts and opts.endpoint)
   local api_key = os.getenv(opts and opts.api_key_name or API_KEY_NAME)
 
   if not api_key then
@@ -115,45 +92,6 @@ function M.make_job(args, writer_fn, on_exit_fn)
     end,
   }
   return active_job
-end
-
----Example implementation of a `make_data_fn` compatible with `kznllm.invoke_llm` for groq spec
----@param prompt_args any
----@param opts any
----@return table
-function M.make_data_for_chat(prompt_args, opts)
-  local template_path = Path:new(opts and opts.template_path or TEMPLATE_PATH)
-  local messages = {
-    {
-      role = 'system',
-      content = kznllm.make_prompt_from_template(template_path / M.MESSAGE_TEMPLATES.FILL_MODE_SYSTEM_PROMPT, prompt_args),
-    },
-    {
-      role = 'user',
-      content = kznllm.make_prompt_from_template(template_path / M.MESSAGE_TEMPLATES.FILL_MODE_USER_PROMPT, prompt_args),
-    },
-  }
-
-  local data = {
-    messages = messages,
-    model = M.MODELS[M.SELECTED_MODEL_IDX].name,
-    temperature = 0.7,
-    stream = true,
-  }
-
-  if opts and opts.debug then
-    local extmark_id = vim.api.nvim_buf_set_extmark(kznllm.BUFFER_STATE.SCRATCH, kznllm.NS_ID, 0, 0, {})
-    kznllm.write_content_at_extmark('model: ' .. M.MODELS[M.SELECTED_MODEL_IDX].name, extmark_id)
-    kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
-    for _, message in ipairs(data.messages) do
-      kznllm.write_content_at_extmark(message.role .. ':\n\n', extmark_id)
-      kznllm.write_content_at_extmark(message.content, extmark_id)
-      kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
-      vim.cmd 'normal! G'
-    end
-  end
-
-  return data
 end
 
 return M

--- a/lua/kznllm/specs/openai.lua
+++ b/lua/kznllm/specs/openai.lua
@@ -1,29 +1,7 @@
-local kznllm = require 'kznllm'
-local Path = require 'plenary.path'
-
 local M = {}
 
 local API_KEY_NAME = 'OPENAI_API_KEY'
-local URL = 'https://api.openai.com/v1/chat/completions'
-
-local TEMPLATE_PATH = vim.fn.expand(vim.fn.stdpath 'data') .. '/lazy/kznllm.nvim'
-
-M.MODELS = {
-  { name = 'gpt-4o-mini', max_tokens = 16384 },
-  { name = 'gpt-4o', max_tokens = 16384 },
-}
-
-M.SELECTED_MODEL_IDX = 1
-
--- for chat completion models using `messages`
-M.MESSAGE_TEMPLATES = {
-  NOUS_RESEARCH = {
-    FILL_MODE_SYSTEM_PROMPT = 'nous_research/fill_mode_system_prompt.xml.jinja',
-    FILL_MODE_USER_PROMPT = 'nous_research/fill_mode_user_prompt.xml.jinja',
-  },
-  FILL_MODE_SYSTEM_PROMPT = 'nous_research/fill_mode_system_prompt.xml.jinja',
-  FILL_MODE_USER_PROMPT = 'nous_research/fill_mode_user_prompt.xml.jinja',
-}
+local BASE_URL = 'https://api.openai.com'
 
 local API_ERROR_MESSAGE = [[
 ERROR: api key is set to %s and is missing from your environment variables.
@@ -38,7 +16,7 @@ local Job = require 'plenary.job'
 ---@param data table
 ---@return string[]
 function M.make_curl_args(data, opts)
-  local url = opts and opts.url or URL
+  local url = (opts and opts.base_url or BASE_URL) .. (opts and opts.endpoint)
   local api_key = os.getenv(opts and opts.api_key_name or API_KEY_NAME)
 
   if not api_key then
@@ -114,45 +92,6 @@ function M.make_job(args, writer_fn, on_exit_fn)
     end,
   }
   return active_job
-end
-
----Example implementation of a `make_data_fn` compatible with `kznllm.invoke_llm` for groq spec
----@param prompt_args any
----@param opts any
----@return table
-function M.make_data_for_chat(prompt_args, opts)
-  local template_path = Path:new(opts and opts.template_path or TEMPLATE_PATH)
-  local messages = {
-    {
-      role = 'system',
-      content = kznllm.make_prompt_from_template(template_path / M.MESSAGE_TEMPLATES.FILL_MODE_SYSTEM_PROMPT, prompt_args),
-    },
-    {
-      role = 'user',
-      content = kznllm.make_prompt_from_template(template_path / M.MESSAGE_TEMPLATES.FILL_MODE_USER_PROMPT, prompt_args),
-    },
-  }
-
-  local data = {
-    messages = messages,
-    model = M.MODELS[M.SELECTED_MODEL_IDX].name,
-    temperature = 0.7,
-    stream = true,
-  }
-
-  if opts and opts.debug then
-    local extmark_id = vim.api.nvim_buf_set_extmark(kznllm.BUFFER_STATE.SCRATCH, kznllm.NS_ID, 0, 0, {})
-    kznllm.write_content_at_extmark('model: ' .. M.MODELS[M.SELECTED_MODEL_IDX].name, extmark_id)
-    kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
-    for _, message in ipairs(data.messages) do
-      kznllm.write_content_at_extmark(message.role .. ':\n\n', extmark_id)
-      kznllm.write_content_at_extmark(message.content, extmark_id)
-      kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
-      vim.cmd 'normal! G'
-    end
-  end
-
-  return data
 end
 
 return M

--- a/lua/kznllm/specs/openai.lua
+++ b/lua/kznllm/specs/openai.lua
@@ -9,15 +9,20 @@ local URL = 'https://api.openai.com/v1/chat/completions'
 local TEMPLATE_PATH = vim.fn.expand(vim.fn.stdpath 'data') .. '/lazy/kznllm.nvim'
 
 M.MODELS = {
-  GPT_4O_MINI = { name = 'gpt-4o-mini', max_tokens = 16384 },
-  GPT_4O = { name = 'gpt-4o', max_tokens = 16384 },
+  { name = 'gpt-4o-mini', max_tokens = 16384 },
+  { name = 'gpt-4o', max_tokens = 16384 },
 }
-M.PROMPT_TEMPLATES = {
 
+M.SELECTED_MODEL_IDX = 1
+
+-- for chat completion models using `messages`
+M.MESSAGE_TEMPLATES = {
   NOUS_RESEARCH = {
     FILL_MODE_SYSTEM_PROMPT = 'nous_research/fill_mode_system_prompt.xml.jinja',
     FILL_MODE_USER_PROMPT = 'nous_research/fill_mode_user_prompt.xml.jinja',
   },
+  FILL_MODE_SYSTEM_PROMPT = 'nous_research/fill_mode_system_prompt.xml.jinja',
+  FILL_MODE_USER_PROMPT = 'nous_research/fill_mode_user_prompt.xml.jinja',
 }
 
 local API_ERROR_MESSAGE = [[
@@ -130,10 +135,22 @@ function M.make_data_for_chat(prompt_args, opts)
 
   local data = {
     messages = messages,
-    model = M.MODELS.GPT_4O_MINI.name,
+    model = M.MODELS[M.SELECTED_MODEL_IDX].name,
     temperature = 0.7,
     stream = true,
   }
+
+  if opts and opts.debug then
+    local extmark_id = vim.api.nvim_buf_set_extmark(kznllm.BUFFER_STATE.SCRATCH, kznllm.NS_ID, 0, 0, {})
+    kznllm.write_content_at_extmark('model: ' .. M.MODELS[M.SELECTED_MODEL_IDX].name, extmark_id)
+    kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+    for _, message in ipairs(data.messages) do
+      kznllm.write_content_at_extmark(message.role .. ':\n\n', extmark_id)
+      kznllm.write_content_at_extmark(message.content, extmark_id)
+      kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+      vim.cmd 'normal! G'
+    end
+  end
 
   return data
 end

--- a/lua/kznllm/specs/openai.lua
+++ b/lua/kznllm/specs/openai.lua
@@ -43,16 +43,11 @@ end
 --- Process server-sent events based on OpenAI spec
 --- [See Documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream)
 ---
----@param out string
+---@param line string
 ---@return string
-local function handle_data(out)
+local function handle_data(line)
   -- based on sse spec (OpenAI spec uses data-only server-sent events)
-  local data, data_epos
-  _, data_epos = string.find(out, '^data: ')
-
-  if data_epos then
-    data = string.sub(out, data_epos + 1)
-  end
+  local data = line:match '^data: (.+)$'
 
   local content = ''
 
@@ -74,8 +69,8 @@ function M.make_job(args, writer_fn, on_exit_fn)
   local active_job = Job:new {
     command = 'curl',
     args = args,
-    on_stdout = function(_, out)
-      local content = handle_data(out)
+    on_stdout = function(_, line)
+      local content = handle_data(line)
       if content and content ~= nil then
         vim.schedule(function()
           writer_fn(content)

--- a/lua/kznllm/specs/vllm.lua
+++ b/lua/kznllm/specs/vllm.lua
@@ -43,16 +43,11 @@ end
 --- Process server-sent events based on OpenAI spec
 --- [See Documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream)
 ---
----@param out string
+---@param line string
 ---@return string
-local function handle_data(out)
+local function handle_data(line)
   -- based on sse spec (OpenAI spec uses data-only server-sent events)
-  local data, data_epos
-  _, data_epos = string.find(out, '^data: ')
-
-  if data_epos then
-    data = string.sub(out, data_epos + 1)
-  end
+  local data = line:match '^data: (.+)$'
 
   local content = ''
 
@@ -74,8 +69,8 @@ function M.make_job(args, writer_fn, on_exit_fn)
   local active_job = Job:new {
     command = 'curl',
     args = args,
-    on_stdout = function(_, out)
-      local content = handle_data(out)
+    on_stdout = function(_, line)
+      local content = handle_data(line)
       if content and content ~= nil then
         vim.schedule(function()
           writer_fn(content)

--- a/lua/kznllm/specs/vllm.lua
+++ b/lua/kznllm/specs/vllm.lua
@@ -1,0 +1,189 @@
+local kznllm = require 'kznllm'
+local Path = require 'plenary.path'
+
+local M = {}
+
+local API_KEY_NAME = 'VLLM_API_KEY'
+-- must provide this
+local URL
+
+local TEMPLATE_PATH = vim.fn.expand(vim.fn.stdpath 'data') .. '/lazy/kznllm.nvim'
+
+M.MODELS = {
+  { name = 'meta-llama/Meta-Llama-3.1-8B', max_tokens = 8192 },
+  { name = 'meta-llama/Meta-Llama-3.1-8B-Instruct', max_tokens = 8192 },
+}
+
+M.SELECTED_MODEL_IDX = 1
+
+-- for chat completion models using `messages`
+M.MESSAGE_TEMPLATES = {
+  NOUS_RESEARCH = {
+    FILL_MODE_SYSTEM_PROMPT = 'nous_research/fill_mode_system_prompt.xml.jinja',
+    FILL_MODE_USER_PROMPT = 'nous_research/fill_mode_user_prompt.xml.jinja',
+  },
+
+  -- defaults
+  FILL_MODE_SYSTEM_PROMPT = 'nous_research/fill_mode_system_prompt.xml.jinja',
+  FILL_MODE_USER_PROMPT = 'nous_research/fill_mode_user_prompt.xml.jinja',
+
+  FILL_MODE_INSTRUCT_COMPLETION_PROMPT = 'vllm/fill_mode_instruct_completion_prompt.xml.jinja',
+}
+
+local API_ERROR_MESSAGE = [[
+ERROR: api key is set to %s and is missing from your environment variables.
+
+Load somewhere safely from config `export %s=<api_key>`]]
+
+local Job = require 'plenary.job'
+
+--- Constructs arguments for constructing an HTTP request to the OpenAI API
+--- using cURL.
+---
+---@param data table
+---@return string[]
+function M.make_curl_args(data, opts)
+  local url = opts and opts.url or URL
+  local api_key = os.getenv(opts and opts.api_key_name or API_KEY_NAME)
+
+  if not api_key then
+    error(API_ERROR_MESSAGE:format(API_KEY_NAME, API_KEY_NAME), 1)
+  end
+
+  local args = {
+    '-s', --silent
+    '-N', --no buffer
+    '-X',
+    'POST',
+    '-H',
+    'Content-Type: application/json',
+    '-d',
+    vim.json.encode(data),
+    '-H',
+    'Authorization: Bearer ' .. api_key,
+    url,
+  }
+
+  return args
+end
+
+--- Process server-sent events based on OpenAI spec
+--- [See Documentation](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream)
+---
+---@param out string
+---@return string
+local function handle_data(out)
+  -- based on sse spec (OpenAI spec uses data-only server-sent events)
+  local data, data_epos
+  _, data_epos = string.find(out, '^data: ')
+
+  if data_epos then
+    data = string.sub(out, data_epos + 1)
+  end
+
+  local content = ''
+
+  if data and data:match '"delta":' then
+    local json = vim.json.decode(data)
+    if json.choices and json.choices[1] and json.choices[1].delta and json.choices[1].delta.content then
+      content = json.choices[1].delta.content
+    else
+      vim.print(data)
+    end
+  end
+
+  return content
+end
+
+---@param args table
+---@param writer_fn fun(content: string)
+function M.make_job(args, writer_fn, on_exit_fn)
+  local active_job = Job:new {
+    command = 'curl',
+    args = args,
+    on_stdout = function(_, out)
+      local content = handle_data(out)
+      if content and content ~= nil then
+        vim.schedule(function()
+          writer_fn(content)
+        end)
+      end
+    end,
+    on_stderr = function(message, _)
+      error(message, 1)
+    end,
+    on_exit = function()
+      vim.schedule(function()
+        on_exit_fn()
+      end)
+    end,
+  }
+  return active_job
+end
+
+---Example implementation of a `make_data_fn` compatible with `kznllm.invoke_llm` for groq spec
+---@param prompt_args any
+---@param opts any
+---@return table
+function M.make_data_for_completions(prompt_args, opts)
+  local template_path = Path:new(opts and opts.template_path or TEMPLATE_PATH)
+
+  local data = {
+    prompt = kznllm.make_prompt_from_template(template_path / M.MESSAGE_TEMPLATES.FILL_MODE_COMPLETION_PROMPT, prompt_args),
+    model = M.MODELS[M.SELECTED_MODEL_IDX].name,
+    temperature = 1.5,
+    min_p = 1.0,
+    stream = true,
+  }
+
+  if opts and opts.debug then
+    local extmark_id = vim.api.nvim_buf_set_extmark(kznllm.BUFFER_STATE.SCRATCH, kznllm.NS_ID, 0, 0, {})
+    kznllm.write_content_at_extmark('model: ' .. M.MODELS[M.SELECTED_MODEL_IDX].name, extmark_id)
+    kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+    kznllm.write_content_at_extmark(data.prompt, extmark_id)
+    kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+    vim.cmd 'normal! G'
+  end
+
+  return data
+end
+---Example implementation of a `make_data_fn` compatible with `kznllm.invoke_llm` for groq spec
+---@param prompt_args any
+---@param opts any
+---@return table
+function M.make_data_for_chat(prompt_args, opts)
+  local template_path = Path:new(opts and opts.template_path or TEMPLATE_PATH)
+  local messages = {
+    {
+      role = 'system',
+      content = kznllm.make_prompt_from_template(template_path / M.MESSAGE_TEMPLATES.FILL_MODE_SYSTEM_PROMPT, prompt_args),
+    },
+    {
+      role = 'user',
+      content = kznllm.make_prompt_from_template(template_path / M.MESSAGE_TEMPLATES.FILL_MODE_USER_PROMPT, prompt_args),
+    },
+  }
+
+  local data = {
+    messages = messages,
+    model = M.MODELS[M.SELECTED_MODEL_IDX].name,
+    temperature = 0.7,
+    stream = true,
+  }
+
+  if opts and opts.debug then
+    local extmark_id = vim.api.nvim_buf_set_extmark(kznllm.BUFFER_STATE.SCRATCH, kznllm.NS_ID, 0, 0, {})
+    kznllm.write_content_at_extmark('model: ' .. M.MODELS[M.SELECTED_MODEL_IDX].name, extmark_id)
+    kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+    for _, message in ipairs(data.messages) do
+      kznllm.write_content_at_extmark(message.role .. ':\n\n', extmark_id)
+      kznllm.write_content_at_extmark(message.content, extmark_id)
+      kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
+      vim.cmd 'normal! G'
+    end
+  end
+
+  return data
+end
+
+return M

--- a/lua/kznllm/specs/vllm.lua
+++ b/lua/kznllm/specs/vllm.lua
@@ -1,34 +1,7 @@
-local kznllm = require 'kznllm'
-local Path = require 'plenary.path'
-
 local M = {}
 
 local API_KEY_NAME = 'VLLM_API_KEY'
--- must provide this
-local URL
-
-local TEMPLATE_PATH = vim.fn.expand(vim.fn.stdpath 'data') .. '/lazy/kznllm.nvim'
-
-M.MODELS = {
-  { name = 'meta-llama/Meta-Llama-3.1-8B', max_tokens = 8192 },
-  { name = 'meta-llama/Meta-Llama-3.1-8B-Instruct', max_tokens = 8192 },
-}
-
-M.SELECTED_MODEL_IDX = 1
-
--- for chat completion models using `messages`
-M.MESSAGE_TEMPLATES = {
-  NOUS_RESEARCH = {
-    FILL_MODE_SYSTEM_PROMPT = 'nous_research/fill_mode_system_prompt.xml.jinja',
-    FILL_MODE_USER_PROMPT = 'nous_research/fill_mode_user_prompt.xml.jinja',
-  },
-
-  -- defaults
-  FILL_MODE_SYSTEM_PROMPT = 'nous_research/fill_mode_system_prompt.xml.jinja',
-  FILL_MODE_USER_PROMPT = 'nous_research/fill_mode_user_prompt.xml.jinja',
-
-  FILL_MODE_INSTRUCT_COMPLETION_PROMPT = 'vllm/fill_mode_instruct_completion_prompt.xml.jinja',
-}
+local BASE_URL -- must provide this
 
 local API_ERROR_MESSAGE = [[
 ERROR: api key is set to %s and is missing from your environment variables.
@@ -43,7 +16,7 @@ local Job = require 'plenary.job'
 ---@param data table
 ---@return string[]
 function M.make_curl_args(data, opts)
-  local url = opts and opts.url or URL
+  local url = (opts and opts.base_url or BASE_URL) .. (opts and opts.endpoint)
   local api_key = os.getenv(opts and opts.api_key_name or API_KEY_NAME)
 
   if not api_key then
@@ -119,71 +92,6 @@ function M.make_job(args, writer_fn, on_exit_fn)
     end,
   }
   return active_job
-end
-
----Example implementation of a `make_data_fn` compatible with `kznllm.invoke_llm` for groq spec
----@param prompt_args any
----@param opts any
----@return table
-function M.make_data_for_completions(prompt_args, opts)
-  local template_path = Path:new(opts and opts.template_path or TEMPLATE_PATH)
-
-  local data = {
-    prompt = kznllm.make_prompt_from_template(template_path / M.MESSAGE_TEMPLATES.FILL_MODE_COMPLETION_PROMPT, prompt_args),
-    model = M.MODELS[M.SELECTED_MODEL_IDX].name,
-    temperature = 1.5,
-    min_p = 1.0,
-    stream = true,
-  }
-
-  if opts and opts.debug then
-    local extmark_id = vim.api.nvim_buf_set_extmark(kznllm.BUFFER_STATE.SCRATCH, kznllm.NS_ID, 0, 0, {})
-    kznllm.write_content_at_extmark('model: ' .. M.MODELS[M.SELECTED_MODEL_IDX].name, extmark_id)
-    kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
-    kznllm.write_content_at_extmark(data.prompt, extmark_id)
-    kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
-    vim.cmd 'normal! G'
-  end
-
-  return data
-end
----Example implementation of a `make_data_fn` compatible with `kznllm.invoke_llm` for groq spec
----@param prompt_args any
----@param opts any
----@return table
-function M.make_data_for_chat(prompt_args, opts)
-  local template_path = Path:new(opts and opts.template_path or TEMPLATE_PATH)
-  local messages = {
-    {
-      role = 'system',
-      content = kznllm.make_prompt_from_template(template_path / M.MESSAGE_TEMPLATES.FILL_MODE_SYSTEM_PROMPT, prompt_args),
-    },
-    {
-      role = 'user',
-      content = kznllm.make_prompt_from_template(template_path / M.MESSAGE_TEMPLATES.FILL_MODE_USER_PROMPT, prompt_args),
-    },
-  }
-
-  local data = {
-    messages = messages,
-    model = M.MODELS[M.SELECTED_MODEL_IDX].name,
-    temperature = 0.7,
-    stream = true,
-  }
-
-  if opts and opts.debug then
-    local extmark_id = vim.api.nvim_buf_set_extmark(kznllm.BUFFER_STATE.SCRATCH, kznllm.NS_ID, 0, 0, {})
-    kznllm.write_content_at_extmark('model: ' .. M.MODELS[M.SELECTED_MODEL_IDX].name, extmark_id)
-    kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
-    for _, message in ipairs(data.messages) do
-      kznllm.write_content_at_extmark(message.role .. ':\n\n', extmark_id)
-      kznllm.write_content_at_extmark(message.content, extmark_id)
-      kznllm.write_content_at_extmark('\n\n---\n\n', extmark_id)
-      vim.cmd 'normal! G'
-    end
-  end
-
-  return data
 end
 
 return M

--- a/templates/nous_research/fill_mode_user_prompt.xml.jinja
+++ b/templates/nous_research/fill_mode_user_prompt.xml.jinja
@@ -9,8 +9,7 @@ Code:
 ```{{current_buffer_filetype}}
 {{ current_buffer_context }}
 ```
-{% endif %}
-{% if context_files %}{% for file_path in context_files %}
+{% endif %}{% if context_files %}{% for file_path in context_files %}
 
 Document:{{loop.index}}
 Title: {{file_path}}

--- a/templates/vllm/fill_mode_instruct_completion_prompt.xml.jinja
+++ b/templates/vllm/fill_mode_instruct_completion_prompt.xml.jinja
@@ -1,0 +1,109 @@
+{{- bos_token }}
+{%- if custom_tools is defined %}
+ {%- set tools = custom_tools %}
+{%- endif %}
+{%- if not tools_in_user_message is defined %}
+ {%- set tools_in_user_message = true %}
+{%- endif %}
+{%- if not date_string is defined %}
+ {%- set date_string = \"26 Jul 2024\" %}
+{%- endif %}
+{%- if not tools is defined %}
+ {%- set tools = none %}
+{%- endif %}
+
+{#- This block extracts the system message, so we can slot it into the right place. #}
+{%- if messages[0]['role'] == 'system' %}
+ {%- set system_message = messages[0]['content']|trim %}
+ {%- set messages = messages[1:] %}
+{%- else %}
+ {%- set system_message = \"\" %}
+{%- endif %}
+
+{#- System message + builtin tools #}
+{{- \"<|start_header_id|>system<|end_header_id|>\n\n\" }}
+{%- if builtin_tools is defined or tools is not none %}
+ {{- \"Environment: ipython\n\" }}
+{%- endif %}
+{%- if builtin_tools is defined %}
+ {{- \"Tools: \" + builtin_tools | reject('equalto', 'code_interpreter') | join(\", \") + \"\n\n\"}}
+{%- endif %}
+{{- \"Cutting Knowledge Date: December 2023\n\" }}
+{{- \"Today Date: \" + date_string + \"\n\n\" }}
+{%- if tools is not none and not tools_in_user_message %}
+ {{- \"You have access to the following functions. To call a function, please respond with JSON for a function call.\" }}
+ {{- 'Respond in the format {\"name\": function name, \"parameters\": dictionary of argument name and its value}.' }}
+ {{- \"Do not use variables.\n\n\" }}
+ {%- for t in tools %}
+ {{- t | tojson(indent=4) }}
+ {{- \"\n\n\" }}
+ {%- endfor %}
+{%- endif %}
+{{- system_message }}
+{{- \"<|eot_id|>\" }}
+
+{#- Custom tools are passed in a user message with some extra guidance #}
+{%- if tools_in_user_message and not tools is none %}
+ {#- Extract the first user message so we can plug it in here #}
+ {%- if messages | length != 0 %}
+ {%- set first_user_message = messages[0]['content']|trim %}
+ {%- set messages = messages[1:] %}
+ {%- else %}
+ {{- raise_exception(\"Cannot put tools in the first user message when there's no first user message!\") }}
+{%- endif %}
+ {{- '<|start_header_id|>user<|end_header_id|>\n\n' -}}
+ {{- \"Given the following functions, please respond with a JSON for a function call \" }}
+ {{- \"with its proper arguments that best answers the given prompt.\n\n\" }}
+ {{- 'Respond in the format {\"name\": function name, \"parameters\": dictionary of argument name and its value}.' }}
+ {{- \"Do not use variables.\n\n\" }}
+ {%- for t in tools %}
+ {{- t | tojson(indent=4) }}
+ {{- \"\n\n\" }}
+ {%- endfor %}
+ {{- first_user_message + \"<|eot_id|>\"}}
+{%- endif %}
+
+{%- for message in messages %}
+ {%- if not (message.role == 'ipython' or message.role == 'tool' or 'tool_calls' in message) %}
+ {{- '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n'+ message['content'] | trim + '<|eot_id|>' }}
+ {%- elif 'tool_calls' in message %}
+ {%- if not message.tool_calls|length == 1 %}
+ {{- raise_exception(\"This model only supports single tool-calls at once!\") }}
+ {%- endif %}
+ {%- set tool_call = message.tool_calls[0].function %}
+ {%- if builtin_tools is defined and tool_call.name in builtin_tools %}
+ {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' -}}
+ {{- \"<|python_tag|>\" + tool_call.name + \".call(\" }}
+ {%- for arg_name, arg_val in tool_call.arguments | items %}
+ {{- arg_name + '=\"' + arg_val + '\"' }}
+ {%- if not loop.last %}
+ {{- \", \" }}
+ {%- endif %}
+ {%- endfor %}
+ {{- \")\" }}
+ {%- else %}
+ {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' -}}
+ {{- '{\"name\": \"' + tool_call.name + '\", ' }}
+ {{- '\"parameters\": ' }}
+ {{- tool_call.arguments | tojson }}
+ {{- \"}\" }}
+ {%- endif %}
+ {%- if builtin_tools is defined %}
+ {#- This means we're in ipython mode #}
+ {{- \"<|eom_id|>\" }}
+ {%- else %}
+ {{- \"<|eot_id|>\" }}
+ {%- endif %}
+ {%- elif message.role == \"tool\" or message.role == \"ipython\" %}
+ {{- \"<|start_header_id|>ipython<|end_header_id|>\n\n\" }}
+ {%- if message.content is mapping or message.content is iterable %}
+ {{- message.content | tojson }}
+ {%- else %}
+ {{- message.content }}
+ {%- endif %}
+ {{- \"<|eot_id|>\" }}
+ {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+ {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' }}
+{%- endif %}


### PR DESCRIPTION
The various parameters each API provider expects can vary greatly (i.e. prompt caching in anthropic, min_p sampling methods in vllm, etc.). 

I'm expecting the supported spec differences between API providers to diverge even further (especially when small local or self-hosted models get good eventually)

The key idea is to make it as easy as possible to retrieve data, pipe it straight into an API, and send the outputs somewhere in your nvim buffer without shooting yourself in the foot with the quirks of nvim.

- want a new feature? write your own variation of `invoke_llm`
- want better api features? add a new `preset` with custom options
- want better prompts? write your own templates (or pipe some more data into a custom `make_data_fn`)

<img width="714" alt="Screenshot 2024-09-05 at 4 40 44 AM" src="https://github.com/user-attachments/assets/82090b06-e97e-4d1e-bc2b-d00ee44373b5">

after rewriting this plugin literally 5 times by now, it's now very clear that model + prompts + api spec + feature set are all very tightly coupled together. what I actually want for myself is a simple way to implement the whole stack of sub-components from scratch and package it together in a preset.

With this refactor, it's relatively easy to add entirely new features without touching the core of the plugin. (i.e. prompt caching, custom params, or fast + slow retrieval)