### PR TITLE
Enable jinja whitespace control

### DIFF
--- a/lua/kznllm/init.lua
+++ b/lua/kznllm/init.lua
@@ -22,7 +22,7 @@ function M.make_prompt_from_template(prompt_template_path, prompt_args)
   local json_data = vim.json.encode(prompt_args)
   local active_job = Job:new {
     command = 'minijinja-cli',
-    args = { '-f', 'json', prompt_template_path:absolute(), '-' },
+    args = { '-f', 'json', '--lstrip-blocks', '--trim-blocks', prompt_template_path:absolute(), '-' },
     writer = json_data,
     on_stderr = function(message, _)
       error(message, 1)


### PR DESCRIPTION
Minijinja allows enabling lstrip_blocks and trim_blocks, which allows templates to be written naturally, with each block on its own line.

For reference: https://jinja.palletsprojects.com/en/3.0.x/templates/#whitespace-control

If needed, I can rewrite the templates without the {%- -%} and the blocks on a new line. Or you can just leave this on and progressively update them at your convenience.

Cheers and thanks for a great plugin.