### PR TITLE
fix off by one error when setting extmark

### DIFF
--- a/lua/kznllm/presets.lua
+++ b/lua/kznllm/presets.lua
@@ -237,7 +237,7 @@ function M.invoke_llm(make_data_fn, make_curl_args_fn, make_job_fn, opts)
       opts.debug_fn(data, M.NS_ID, stream_end_extmark_id, opts)
     else
       local _, crow, ccol = unpack(vim.fn.getpos '.')
-      stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol, { strict = false })
+      stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol - 1, { strict = false })
     end
 
     local args = make_curl_args_fn(data, opts)


### PR DESCRIPTION
Resolves: https://github.com/chottolabs/kznllm.nvim/issues/19

Was never really noticeable to me because I always use visual-lines and when the whole line gets deleted the OBO position on extmark doesn't make a difference