### PR TITLE
Fix anthropic template not being passed prompt args

### DIFF
--- a/lua/kznllm/presets.lua
+++ b/lua/kznllm/presets.lua
@@ -104,7 +104,7 @@ end
 ---@return table
 local function make_data_for_anthropic_chat(prompt_args, opts)
   local data = {
-    system = kznllm.make_prompt_from_template(opts.template_directory / 'anthropic/fill_mode_system_prompt.xml.jinja', {}),
+    system = kznllm.make_prompt_from_template(opts.template_directory / 'anthropic/fill_mode_system_prompt.xml.jinja', prompt_args),
     messages = {
       {
         role = 'user',


### PR DESCRIPTION
The template wont correctly render without this param being passed, so the anthropic preset currently fails (without a good error msg so it might be worth looking into strengthening handling minijinja errors).