### PR TITLE
Improve curl error handling

### DIFF
--- a/lua/kznllm/specs/deepseek.lua
+++ b/lua/kznllm/specs/deepseek.lua
@@ -25,6 +25,7 @@ function M.make_curl_args(data, opts)
 
   local args = {
     '-s', --silent
+    '--fail-with-body',
     '-N', --no buffer
     '-X',
     'POST',
@@ -69,6 +70,7 @@ function M.make_job(args, writer_fn, on_exit_fn)
   local active_job = Job:new {
     command = 'curl',
     args = args,
+    enable_recording = true,
     on_stdout = function(_, line)
       local content = handle_data(line)
       if content and content ~= nil then
@@ -80,9 +82,16 @@ function M.make_job(args, writer_fn, on_exit_fn)
     on_stderr = function(message, _)
       error(message, 1)
     end,
-    on_exit = function()
+    on_exit = function(job, exit_code)
+      local stdout_result = job:result()
+      local stdout_message = table.concat(stdout_result, '\n')
+
       vim.schedule(function()
-        on_exit_fn()
+        if exit_code ~= 0 then
+          vim.notify('[Curl] (exit code: ' .. exit_code .. ')\n' .. stdout_message, vim.log.levels.ERROR)
+        else
+          on_exit_fn()
+        end
       end)
     end,
   }

--- a/lua/kznllm/specs/groq.lua
+++ b/lua/kznllm/specs/groq.lua
@@ -25,6 +25,7 @@ function M.make_curl_args(data, opts)
 
   local args = {
     '-s', --silent
+    '--fail-with-body', --silent
     '-N', --no buffer
     '-X',
     'POST',
@@ -69,6 +70,7 @@ function M.make_job(args, writer_fn, on_exit_fn)
   local active_job = Job:new {
     command = 'curl',
     args = args,
+    enable_recording = true,
     on_stdout = function(_, line)
       local content = handle_data(line)
       if content and content ~= nil then
@@ -80,9 +82,16 @@ function M.make_job(args, writer_fn, on_exit_fn)
     on_stderr = function(message, _)
       error(message, 1)
     end,
-    on_exit = function()
+    on_exit = function(job, exit_code)
+      local stdout_result = job:result()
+      local stdout_message = table.concat(stdout_result, '\n')
+
       vim.schedule(function()
-        on_exit_fn()
+        if exit_code ~= 0 then
+          vim.notify('[Curl] (exit code: ' .. exit_code .. ')\n' .. stdout_message, vim.log.levels.ERROR)
+        else
+          on_exit_fn()
+        end
       end)
     end,
   }

--- a/lua/kznllm/specs/lambda.lua
+++ b/lua/kznllm/specs/lambda.lua
@@ -25,6 +25,7 @@ function M.make_curl_args(data, opts)
 
   local args = {
     '-s', --silent
+    '--fail-with-body',
     '-N', --no buffer
     '-X',
     'POST',
@@ -69,6 +70,7 @@ function M.make_job(args, writer_fn, on_exit_fn)
   local active_job = Job:new {
     command = 'curl',
     args = args,
+    enable_recording = true,
     on_stdout = function(_, line)
       local content = handle_data(line)
       if content and content ~= nil then
@@ -80,9 +82,16 @@ function M.make_job(args, writer_fn, on_exit_fn)
     on_stderr = function(message, _)
       error(message, 1)
     end,
-    on_exit = function()
+    on_exit = function(job, exit_code)
+      local stdout_result = job:result()
+      local stdout_message = table.concat(stdout_result, '\n')
+
       vim.schedule(function()
-        on_exit_fn()
+        if exit_code ~= 0 then
+          vim.notify('[Curl] (exit code: ' .. exit_code .. ')\n' .. stdout_message, vim.log.levels.ERROR)
+        else
+          on_exit_fn()
+        end
       end)
     end,
   }

--- a/lua/kznllm/specs/openai.lua
+++ b/lua/kznllm/specs/openai.lua
@@ -25,6 +25,7 @@ function M.make_curl_args(data, opts)
 
   local args = {
     '-s', --silent
+    '--fail-with-body',
     '-N', --no buffer
     '-X',
     'POST',
@@ -69,6 +70,7 @@ function M.make_job(args, writer_fn, on_exit_fn)
   local active_job = Job:new {
     command = 'curl',
     args = args,
+    enable_recording = true,
     on_stdout = function(_, line)
       local content = handle_data(line)
       if content and content ~= nil then
@@ -80,9 +82,16 @@ function M.make_job(args, writer_fn, on_exit_fn)
     on_stderr = function(message, _)
       error(message, 1)
     end,
-    on_exit = function()
+    on_exit = function(job, exit_code)
+      local stdout_result = job:result()
+      local stdout_message = table.concat(stdout_result, '\n')
+
       vim.schedule(function()
-        on_exit_fn()
+        if exit_code ~= 0 then
+          vim.notify('[Curl] (exit code: ' .. exit_code .. ')\n' .. stdout_message, vim.log.levels.ERROR)
+        else
+          on_exit_fn()
+        end
       end)
     end,
   }

--- a/lua/kznllm/specs/vllm.lua
+++ b/lua/kznllm/specs/vllm.lua
@@ -25,6 +25,7 @@ function M.make_curl_args(data, opts)
 
   local args = {
     '-s', --silent
+    '--fail-with-body', --silent
     '-N', --no buffer
     '-X',
     'POST',
@@ -69,6 +70,7 @@ function M.make_job(args, writer_fn, on_exit_fn)
   local active_job = Job:new {
     command = 'curl',
     args = args,
+    enable_recording = true,
     on_stdout = function(_, line)
       local content = handle_data(line)
       if content and content ~= nil then
@@ -80,9 +82,16 @@ function M.make_job(args, writer_fn, on_exit_fn)
     on_stderr = function(message, _)
       error(message, 1)
     end,
-    on_exit = function()
+    on_exit = function(job, exit_code)
+      local stdout_result = job:result()
+      local stdout_message = table.concat(stdout_result, '\n')
+
       vim.schedule(function()
-        on_exit_fn()
+        if exit_code ~= 0 then
+          vim.notify('[Curl] (exit code: ' .. exit_code .. ')\n' .. stdout_message, vim.log.levels.ERROR)
+        else
+          on_exit_fn()
+        end
       end)
     end,
   }


### PR DESCRIPTION
I noticed that plenary.job does call on_stdout when the job errors.
This is probably a good thing but curl still writes to stdout when the server responds with an error code.
So if we capture stdout and print it when the exit code is not 0, we can show users a useful error code an error response.
For example, when trying to make a request to anthropic with an invalid api key:

before:
![before](https://github.com/user-attachments/assets/6f923abf-fc53-4e81-b619-195cb25b24fa)
after
![curl_after](https://github.com/user-attachments/assets/dec8713c-3ed2-4275-85c5-3833237c87df)
