### PR TITLE
Correctly print missing api key

### DIFF
--- a/lua/kznllm/specs/anthropic.lua
+++ b/lua/kznllm/specs/anthropic.lua
@@ -18,10 +18,11 @@ local current_event_state = nil
 ---@return string[]
 function M.make_curl_args(data, opts)
   local url = (opts and opts.base_url or BASE_URL) .. (opts and opts.endpoint)
-  local api_key = os.getenv(opts and opts.api_key_name or API_KEY_NAME)
+  local api_key_name = opts and opts.api_key_name or API_KEY_NAME
+  local api_key = os.getenv(api_key_name)
 
   if not api_key then
-    error(API_ERROR_MESSAGE:format(API_KEY_NAME, API_KEY_NAME), 1)
+    error(API_ERROR_MESSAGE:format(api_key_name, api_key_name), 1)
   end
 
   local args = {

--- a/lua/kznllm/specs/deepseek.lua
+++ b/lua/kznllm/specs/deepseek.lua
@@ -17,10 +17,11 @@ local Job = require 'plenary.job'
 ---@return string[]
 function M.make_curl_args(data, opts)
   local url = (opts and opts.base_url or BASE_URL) .. (opts and opts.endpoint)
-  local api_key = os.getenv(opts and opts.api_key_name or API_KEY_NAME)
+  local api_key_name = opts and opts.api_key_name or API_KEY_NAME
+  local api_key = os.getenv(api_key_name)
 
   if not api_key then
-    error(API_ERROR_MESSAGE:format(API_KEY_NAME, API_KEY_NAME), 1)
+    error(API_ERROR_MESSAGE:format(api_key_name, api_key_name), 1)
   end
 
   local args = {

--- a/lua/kznllm/specs/groq.lua
+++ b/lua/kznllm/specs/groq.lua
@@ -17,10 +17,11 @@ local Job = require 'plenary.job'
 ---@return string[]
 function M.make_curl_args(data, opts)
   local url = (opts and opts.base_url or BASE_URL) .. (opts and opts.endpoint)
-  local api_key = os.getenv(opts and opts.api_key_name or API_KEY_NAME)
+  local api_key_name = opts and opts.api_key_name or API_KEY_NAME
+  local api_key = os.getenv(api_key_name)
 
   if not api_key then
-    error(API_ERROR_MESSAGE:format(API_KEY_NAME, API_KEY_NAME), 1)
+    error(API_ERROR_MESSAGE:format(api_key_name, api_key_name), 1)
   end
 
   local args = {

--- a/lua/kznllm/specs/lambda.lua
+++ b/lua/kznllm/specs/lambda.lua
@@ -17,10 +17,11 @@ local Job = require 'plenary.job'
 ---@return string[]
 function M.make_curl_args(data, opts)
   local url = (opts and opts.base_url or BASE_URL) .. (opts and opts.endpoint)
-  local api_key = os.getenv(opts and opts.api_key_name or API_KEY_NAME)
+  local api_key_name = opts and opts.api_key_name or API_KEY_NAME
+  local api_key = os.getenv(api_key_name)
 
   if not api_key then
-    error(API_ERROR_MESSAGE:format(API_KEY_NAME, API_KEY_NAME), 1)
+    error(API_ERROR_MESSAGE:format(api_key_name, api_key_name), 1)
   end
 
   local args = {

--- a/lua/kznllm/specs/openai.lua
+++ b/lua/kznllm/specs/openai.lua
@@ -17,10 +17,11 @@ local Job = require 'plenary.job'
 ---@return string[]
 function M.make_curl_args(data, opts)
   local url = (opts and opts.base_url or BASE_URL) .. (opts and opts.endpoint)
-  local api_key = os.getenv(opts and opts.api_key_name or API_KEY_NAME)
+  local api_key_name = opts and opts.api_key_name or API_KEY_NAME
+  local api_key = os.getenv(api_key_name)
 
   if not api_key then
-    error(API_ERROR_MESSAGE:format(API_KEY_NAME, API_KEY_NAME), 1)
+    error(API_ERROR_MESSAGE:format(api_key_name, api_key_name), 1)
   end
 
   local args = {

--- a/lua/kznllm/specs/vllm.lua
+++ b/lua/kznllm/specs/vllm.lua
@@ -17,10 +17,11 @@ local Job = require 'plenary.job'
 ---@return string[]
 function M.make_curl_args(data, opts)
   local url = (opts and opts.base_url or BASE_URL) .. (opts and opts.endpoint)
-  local api_key = os.getenv(opts and opts.api_key_name or API_KEY_NAME)
+  local api_key_name = opts and opts.api_key_name or API_KEY_NAME
+  local api_key = os.getenv(api_key_name)
 
   if not api_key then
-    error(API_ERROR_MESSAGE:format(API_KEY_NAME, API_KEY_NAME), 1)
+    error(API_ERROR_MESSAGE:format(api_key_name, api_key_name), 1)
   end
 
   local args = {


### PR DESCRIPTION
Here is a small one: when setting a custom api key name and forgetting to set its value the error message will incorrectly prompt you to set the default variable name, not the custom one.