### PR TITLE
Fix srow -> erow switching when in visual mode

### DIFF
--- a/lua/kznllm/init.lua
+++ b/lua/kznllm/init.lua
@@ -94,12 +94,8 @@ function M.get_visual_selection(opts)
 
   -- normalize start + end such that start_pos < end_pos and converts to 0-index
   srow, scol, erow, ecol = srow - 1, scol - 1, erow - 1, ecol - 1
-  if srow > erow then
-    srow, erow = erow, srow
-  end
-
-  if scol > ecol then
-    scol, ecol = ecol, scol
+  if srow > erow or (srow == erow and scol > ecol) then
+    srow, erow, scol, ecol = erow, srow, ecol, scol
   end
 
   -- in visual block and visual line mode, we expect first column of srow and last column of erow


### PR DESCRIPTION
The logic for switching the start row and end row is not quite correct and is only evident when in visual mode:

![before_cur](https://github.com/user-attachments/assets/7551ae25-de9d-487d-a0b5-5db6a17242fd)

after

![after_cur](https://github.com/user-attachments/assets/4fbe2d00-ed14-4974-bcbd-bdb7f599be71)