### PR TITLE
Fix visual selection at end column

### DIFF
--- a/lua/kznllm/init.lua
+++ b/lua/kznllm/init.lua
@@ -101,11 +101,6 @@ function M.get_visual_selection(opts)
   -- in visual block and visual line mode, we expect first column of srow and last column of erow
   if mode == 'V' or mode == '\22' or mode == 'n' then
     scol, ecol = 0, -1
-  else
-    -- in visual mode we need to include the last column of erow
-    -- capped at the row length, as visual mode can move the cursor past the row end
-    local erow_content = vim.api.nvim_buf_get_lines(0, erow, erow + 1, false)[1]
-    ecol = math.min(ecol + 1, #erow_content)
   end
 
   -- handling + cleanup for visual selection

--- a/lua/kznllm/init.lua
+++ b/lua/kznllm/init.lua
@@ -101,6 +101,11 @@ function M.get_visual_selection(opts)
   -- in visual block and visual line mode, we expect first column of srow and last column of erow
   if mode == 'V' or mode == '\22' or mode == 'n' then
     scol, ecol = 0, -1
+  else
+    local erow_content = vim.api.nvim_buf_get_lines(0, erow, erow + 1, false)[1]
+    if ecol < #erow_content then
+      ecol = ecol + 1
+    end
   end
 
   -- handling + cleanup for visual selection
@@ -117,7 +122,7 @@ function M.get_visual_selection(opts)
     api.nvim_buf_set_text(0, srow, scol, erow, ecol, {})
   end
 
-  return visual_selection
+  return visual_selection, srow, scol, erow, ecol
 end
 
 ---Locates the path value for context directory

--- a/lua/kznllm/init.lua
+++ b/lua/kznllm/init.lua
@@ -102,7 +102,10 @@ function M.get_visual_selection(opts)
   if mode == 'V' or mode == '\22' or mode == 'n' then
     scol, ecol = 0, -1
   else
-    ecol = ecol + 1
+    -- in visual mode we need to include the last column of erow
+    -- capped at the row length, as visual mode can move the cursor past the row end
+    local erow_content = vim.api.nvim_buf_get_lines(0, erow, erow + 1, false)[1]
+    ecol = math.min(ecol + 1, #erow_content)
   end
 
   -- handling + cleanup for visual selection

--- a/lua/kznllm/presets.lua
+++ b/lua/kznllm/presets.lua
@@ -245,7 +245,12 @@ function M.invoke_llm(make_data_fn, make_curl_args_fn, make_job_fn, opts)
       opts.debug_fn(data, M.NS_ID, stream_end_extmark_id, opts)
     else
       local _, crow, ccol = unpack(vim.fn.getpos '.')
-      stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol - 1, { strict = false })
+      local crow_content = vim.api.nvim_buf_get_lines(0, crow - 1, crow, false)[1]
+      if ccol == #crow_content then
+        stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol, { strict = false })
+      else
+        stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol - 1, { strict = false })
+      end
     end
 
     local args = make_curl_args_fn(data, opts)

--- a/lua/kznllm/presets.lua
+++ b/lua/kznllm/presets.lua
@@ -245,12 +245,14 @@ function M.invoke_llm(make_data_fn, make_curl_args_fn, make_job_fn, opts)
       opts.debug_fn(data, M.NS_ID, stream_end_extmark_id, opts)
     else
       local _, crow, ccol = unpack(vim.fn.getpos '.')
+
+      -- handle edge case where the original cursor position gets pushed left during replacement
       local crow_content = vim.api.nvim_buf_get_lines(0, crow - 1, crow, false)[1]
       if ccol == #crow_content then
-        stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol, { strict = false })
-      else
-        stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol - 1, { strict = false })
+        ccol = ccol + 1
       end
+
+      stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol - 1, { strict = false })
     end
 
     local args = make_curl_args_fn(data, opts)

--- a/lua/kznllm/presets.lua
+++ b/lua/kznllm/presets.lua
@@ -200,7 +200,7 @@ function M.invoke_llm(make_data_fn, make_curl_args_fn, make_job_fn, opts)
     M.PROMPT_ARGS_STATE.user_query = input
     M.PROMPT_ARGS_STATE.replace = not (api.nvim_get_mode().mode == 'n')
 
-    local visual_selection = kznllm.get_visual_selection(opts)
+    local visual_selection, crow, ccol = kznllm.get_visual_selection(opts)
     M.PROMPT_ARGS_STATE.visual_selection = visual_selection
 
     local context_dir = kznllm.find_context_directory(opts)
@@ -244,15 +244,7 @@ function M.invoke_llm(make_data_fn, make_curl_args_fn, make_job_fn, opts)
       stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.SCRATCH, M.NS_ID, 0, 0, {})
       opts.debug_fn(data, M.NS_ID, stream_end_extmark_id, opts)
     else
-      local _, crow, ccol = unpack(vim.fn.getpos '.')
-
-      -- handle edge case where the original cursor position gets pushed left during replacement
-      local crow_content = vim.api.nvim_buf_get_lines(0, crow - 1, crow, false)[1]
-      if ccol == #crow_content then
-        ccol = ccol + 1
-      end
-
-      stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol - 1, { strict = false })
+      stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow, ccol, { strict = false })
     end
 
     local args = make_curl_args_fn(data, opts)

--- a/lua/kznllm/presets.lua
+++ b/lua/kznllm/presets.lua
@@ -245,7 +245,7 @@ function M.invoke_llm(make_data_fn, make_curl_args_fn, make_job_fn, opts)
       opts.debug_fn(data, M.NS_ID, stream_end_extmark_id, opts)
     else
       local _, crow, ccol = unpack(vim.fn.getpos '.')
-      stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol, { strict = false })
+      stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol - 1, { strict = false })
     end
 
     local args = make_curl_args_fn(data, opts)

--- a/lua/kznllm/presets.lua
+++ b/lua/kznllm/presets.lua
@@ -245,7 +245,7 @@ function M.invoke_llm(make_data_fn, make_curl_args_fn, make_job_fn, opts)
       opts.debug_fn(data, M.NS_ID, stream_end_extmark_id, opts)
     else
       local _, crow, ccol = unpack(vim.fn.getpos '.')
-      stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol - 1, { strict = false })
+      stream_end_extmark_id = api.nvim_buf_set_extmark(M.BUFFER_STATE.ORIGIN, M.NS_ID, crow - 1, ccol, { strict = false })
     end
 
     local args = make_curl_args_fn(data, opts)


### PR DESCRIPTION
Visual mode, again!

I found that the cursor can be bigger than the actual line length. We must cap the visual selection to the line length in that case.

before: (notice that the cursor position is not actually at `}` but one character to the right)
![visual_cur_before](https://github.com/user-attachments/assets/8d1d1377-8275-44dc-901c-59b066f6c2e6)
after:
![visual_cur_after](https://github.com/user-attachments/assets/3d78a139-0636-49ff-8786-f85d65982a48)
