### PR TITLE
Mark the current preset in the preset switcher

### DIFF
--- a/lua/kznllm/presets.lua
+++ b/lua/kznllm/presets.lua
@@ -259,6 +259,8 @@ function M.invoke_llm(make_data_fn, make_curl_args_fn, make_job_fn, opts)
 end
 
 function M.switch_presets()
+  local _, selected_preset = M.load()
+
   vim.ui.select(presets, {
     format_item = function(item)
       local options = {}
@@ -277,7 +279,7 @@ function M.switch_presets()
         end
       end
       table.sort(options)
-      return ('%-20s %10s | %s'):format(item.id, item.provider, table.concat(options, ' '))
+      return ('%-20s %10s | %s'):format(item.id .. (item == selected_preset and ' *' or '  '), item.provider, table.concat(options, ' '))
     end,
   }, function(choice, idx)
     if not choice then


### PR DESCRIPTION
Hi! A little addition to show a mark next to the current preset, now that the selected preset is persisted.
What do you think?  I went the simplest way, but could we highlight it instead?

![image](https://github.com/user-attachments/assets/c3e03337-968d-4116-ba1d-4cebd3bc07b5)
